### PR TITLE
Ignore unrated entries when calculating averages

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Al activarlo se crearán automáticamente las tablas personalizadas donde se alm
 - Utiliza los shortcodes `[grafica_bar_form]` y `[grafica_empleado_form]` para mostrar los formularios de valoración.
 - Inserta los bloques "Gráfica Bar" o "Gráfica Empleado" en el editor para visualizar los promedios.
 
+Si se deja un criterio sin valorar, la puntuación guardada es 0 y no se tendrá en cuenta para el promedio final.
+
 ## Desinstalación
 
 Al desinstalar el plugin se eliminan las tablas creadas para almacenar los resultados.

--- a/inc/grafica-bar.php
+++ b/inc/grafica-bar.php
@@ -94,7 +94,8 @@ $results = $wpdb->get_results($wpdb->prepare("
         $count       = 0;
         foreach ($results as $row) {
             foreach ($campos as $campo) {
-                if (isset($row->$campo)) {
+                // Un valor 0 indica que el criterio no fue valorado y se ignora
+                if (isset($row->$campo) && $row->$campo != 0) {
                     $total_grupo += $row->$campo;
                     $count++;
                 }

--- a/inc/grafica-empleado.php
+++ b/inc/grafica-empleado.php
@@ -69,7 +69,8 @@ function renderizar_bloque_grafica_empleado($attributes, $content) {
         $count = 0;
         foreach ($results as $row) {
             foreach ($campos as $campo) {
-                if (isset($row->$campo)) {
+                // Un valor 0 significa que el criterio se dejó en blanco y no cuenta
+                if (isset($row->$campo) && $row->$campo != 0) {
                     $total_grupo += $row->$campo;
                     $count++;
                 }


### PR DESCRIPTION
## Summary
- skip unrated criteria in bar and employee charts
- note that leaving a criterion blank won't affect the score

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68856fedcc008327ba547c6fdcf1a7cc