### PR TITLE
Add color picker with alpha channel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Dentro del menú **CdB Gráfica** se encuentra el submenú **Configurar Colores*
 - **Bar – Color de fondo** y **Bar – Color de borde** definen el aspecto del dataset de bares.
 - **Empleado – Color de fondo** y **Empleado – Color de borde** controlan el dataset de empleados.
 
+Cada selector cuenta con un deslizador *Alpha* que permite ajustar la transparencia del color. Los valores se guardan en formato `rgba`, por lo que puedes elegir tonalidades semitransparentes que se aplicarán directamente en las gráficas.
+
 Al guardar los cambios, los nuevos valores se aplican automáticamente a las gráficas del sitio. El color de borde también se utiliza para los *ticks* de la escala, por lo que puedes ajustar su tonalidad desde esta misma pantalla.
 
 ## Desinstalación

--- a/admin/color-picker-alpha.css
+++ b/admin/color-picker-alpha.css
@@ -1,0 +1,10 @@
+.cdb-alpha-slider {
+    margin-top:8px;
+    width: 100%;
+    height: 12px;
+}
+.cdb-alpha-slider .ui-slider-handle {
+    height: 14px;
+    width: 14px;
+    top: -1px;
+}

--- a/admin/color-picker-alpha.js
+++ b/admin/color-picker-alpha.js
@@ -1,0 +1,50 @@
+(function($){
+    function parseRgba(val){
+        var m = val.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d+(?:\.\d+)?))?\)/);
+        if(m){
+            return {r:parseInt(m[1],10), g:parseInt(m[2],10), b:parseInt(m[3],10), a:m[4]?parseFloat(m[4]):1};
+        }
+        return null;
+    }
+    function hexToRgb(hex){
+        hex = hex.replace('#','');
+        if(hex.length===3){ hex = hex.replace(/(.)/g,'$1$1'); }
+        var num = parseInt(hex,16);
+        return {r:(num>>16)&255, g:(num>>8)&255, b:num&255};
+    }
+    $.fn.cdbColorPickerAlpha = function(opts){
+        var settings = $.extend({alpha:true}, opts);
+        return this.each(function(){
+            var $input = $(this);
+            var rgba = parseRgba($input.val()) || {r:0,g:0,b:0,a:1};
+            var initColor = 'rgb('+rgba.r+','+rgba.g+','+rgba.b+')';
+            $input.val(initColor);
+            $input.wpColorPicker({change:update, clear:update});
+            var $container = $input.closest('.wp-picker-container');
+            var $holder = $container.find('.wp-picker-holder');
+            var $alpha = $('<div class="cdb-alpha-slider"></div>').insertAfter($holder);
+            $alpha.slider({
+                min:0,max:100,step:1,value:Math.round(rgba.a*100),
+                slide:function(e,ui){rgba.a=ui.value/100;update();},
+                change:function(e,ui){rgba.a=ui.value/100;update();}
+            });
+            function update(){
+                var color = $input.wpColorPicker('color');
+                var rgb;
+                if(color.charAt(0)==='#'){
+                    rgb = hexToRgb(color);
+                    color = 'rgba('+rgb.r+','+rgb.g+','+rgb.b+','+rgba.a+')';
+                } else if(color.indexOf('rgb')===0){
+                    color = color.replace(')',','+rgba.a+')').replace('rgb','rgba');
+                }
+                $input.val(color);
+                $container.find('.wp-color-result').css('background-color', color);
+            }
+            update();
+        });
+    };
+})(jQuery);
+
+jQuery(function($){
+    $('.cdb-color-field').cdbColorPickerAlpha({alpha:true});
+});

--- a/admin/modificar_colores.php
+++ b/admin/modificar_colores.php
@@ -38,6 +38,23 @@ function cdb_grafica_colores_page() {
 
     wp_enqueue_style('wp-color-picker');
     wp_enqueue_script('wp-color-picker');
+
+    $alpha_css_path = plugin_dir_path(__FILE__) . 'color-picker-alpha.css';
+    wp_enqueue_style(
+        'cdb-color-picker-alpha',
+        plugins_url('admin/color-picker-alpha.css', dirname(__FILE__)),
+        ['wp-color-picker'],
+        filemtime($alpha_css_path)
+    );
+
+    $alpha_js_path = plugin_dir_path(__FILE__) . 'color-picker-alpha.js';
+    wp_enqueue_script(
+        'cdb-color-picker-alpha',
+        plugins_url('admin/color-picker-alpha.js', dirname(__FILE__)),
+        ['wp-color-picker', 'jquery', 'jquery-ui-slider'],
+        filemtime($alpha_js_path),
+        true
+    );
     ?>
     <div class="wrap">
         <h1>Configurar Colores</h1>
@@ -74,7 +91,7 @@ function cdb_grafica_colores_page() {
     </div>
     <script>
     jQuery(document).ready(function($){
-        $('.cdb-color-field').wpColorPicker();
+        $('.cdb-color-field').cdbColorPickerAlpha({alpha: true});
     });
     </script>
     <?php


### PR DESCRIPTION
## Summary
- add custom `cdbColorPickerAlpha` script and styles
- enqueue the alpha picker in the admin page
- initialize `.cdb-color-field` with `alpha: true`
- document how to use transparent colors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885834955e48327b16a236fbeb7f1dd