### PR TITLE
Add manual alpha fields for color settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Dentro del menú **CdB Gráfica** se encuentra el submenú **Configurar Colores*
 - **Bar – Color de fondo** y **Bar – Color de borde** definen el aspecto del dataset de bares.
 - **Empleado – Color de fondo** y **Empleado – Color de borde** controlan el dataset de empleados.
 
+Junto a cada selector de color hay un campo *Alpha* para introducir un valor entre `0` y `1`. Este número controla la transparencia aplicada al color. El plugin combina ambos valores internamente para generar el código `rgba` necesario en las gráficas.
+
 Al guardar los cambios, los nuevos valores se aplican automáticamente a las gráficas del sitio. El color de borde también se utiliza para los *ticks* de la escala, por lo que puedes ajustar su tonalidad desde esta misma pantalla.
 
 ## Desinstalación

--- a/admin/color-picker-alpha.css
+++ b/admin/color-picker-alpha.css
@@ -1,0 +1,10 @@
+.cdb-alpha-slider {
+    margin-top:8px;
+    width: 100%;
+    height: 12px;
+}
+.cdb-alpha-slider .ui-slider-handle {
+    height: 14px;
+    width: 14px;
+    top: -1px;
+}

--- a/admin/color-picker-alpha.js
+++ b/admin/color-picker-alpha.js
@@ -1,0 +1,50 @@
+(function($){
+    function parseRgba(val){
+        var m = val.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d+(?:\.\d+)?))?\)/);
+        if(m){
+            return {r:parseInt(m[1],10), g:parseInt(m[2],10), b:parseInt(m[3],10), a:m[4]?parseFloat(m[4]):1};
+        }
+        return null;
+    }
+    function hexToRgb(hex){
+        hex = hex.replace('#','');
+        if(hex.length===3){ hex = hex.replace(/(.)/g,'$1$1'); }
+        var num = parseInt(hex,16);
+        return {r:(num>>16)&255, g:(num>>8)&255, b:num&255};
+    }
+    $.fn.cdbColorPickerAlpha = function(opts){
+        var settings = $.extend({alpha:true}, opts);
+        return this.each(function(){
+            var $input = $(this);
+            var rgba = parseRgba($input.val()) || {r:0,g:0,b:0,a:1};
+            var initColor = 'rgb('+rgba.r+','+rgba.g+','+rgba.b+')';
+            $input.val(initColor);
+            $input.wpColorPicker({change:update, clear:update});
+            var $container = $input.closest('.wp-picker-container');
+            var $holder = $container.find('.wp-picker-holder');
+            var $alpha = $('<div class="cdb-alpha-slider"></div>').insertAfter($holder);
+            $alpha.slider({
+                min:0,max:100,step:1,value:Math.round(rgba.a*100),
+                slide:function(e,ui){rgba.a=ui.value/100;update();},
+                change:function(e,ui){rgba.a=ui.value/100;update();}
+            });
+            function update(){
+                var color = $input.wpColorPicker('color');
+                var rgb;
+                if(color.charAt(0)==='#'){
+                    rgb = hexToRgb(color);
+                    color = 'rgba('+rgb.r+','+rgb.g+','+rgb.b+','+rgba.a+')';
+                } else if(color.indexOf('rgb')===0){
+                    color = color.replace(')',','+rgba.a+')').replace('rgb','rgba');
+                }
+                $input.val(color);
+                $container.find('.wp-color-result').css('background-color', color);
+            }
+            update();
+        });
+    };
+})(jQuery);
+
+jQuery(function($){
+    $('.cdb-color-field').cdbColorPickerAlpha({alpha:true});
+});

--- a/admin/modificar_colores.php
+++ b/admin/modificar_colores.php
@@ -12,32 +12,64 @@ function cdb_grafica_colores_menu() {
 }
 add_action('admin_menu', 'cdb_grafica_colores_menu');
 
+function cdb_rgba_to_hex_alpha($value) {
+    if (preg_match('/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([0-9.]+))?\)/', $value, $m)) {
+        $hex   = sprintf('#%02x%02x%02x', $m[1], $m[2], $m[3]);
+        $alpha = isset($m[4]) ? floatval($m[4]) : 1;
+        return [$hex, $alpha];
+    }
+    return [$value, 1];
+}
+
 function cdb_grafica_colores_page() {
     if (isset($_POST['cdb_grafica_colores_nonce']) && wp_verify_nonce($_POST['cdb_grafica_colores_nonce'], 'cdb_guardar_colores')) {
         $colores = [
-            'bar_background'      => sanitize_text_field($_POST['bar_background'] ?? ''),
-            'bar_border'          => sanitize_text_field($_POST['bar_border'] ?? ''),
-            'empleado_background' => sanitize_text_field($_POST['empleado_background'] ?? ''),
-            'empleado_border'     => sanitize_text_field($_POST['empleado_border'] ?? ''),
-            'ticks_color'         => sanitize_text_field($_POST['ticks_color'] ?? ''),
-            'ticks_backdrop'      => sanitize_text_field($_POST['ticks_backdrop'] ?? ''),
+            'bar_background'          => sanitize_text_field($_POST['bar_background'] ?? ''),
+            'bar_background_alpha'    => max(0, min(1, floatval($_POST['bar_background_alpha'] ?? '1'))),
+            'bar_border'              => sanitize_text_field($_POST['bar_border'] ?? ''),
+            'bar_border_alpha'        => max(0, min(1, floatval($_POST['bar_border_alpha'] ?? '1'))),
+            'empleado_background'     => sanitize_text_field($_POST['empleado_background'] ?? ''),
+            'empleado_background_alpha' => max(0, min(1, floatval($_POST['empleado_background_alpha'] ?? '1'))),
+            'empleado_border'         => sanitize_text_field($_POST['empleado_border'] ?? ''),
+            'empleado_border_alpha'   => max(0, min(1, floatval($_POST['empleado_border_alpha'] ?? '1'))),
+            'ticks_color'             => sanitize_text_field($_POST['ticks_color'] ?? ''),
+            'ticks_color_alpha'       => max(0, min(1, floatval($_POST['ticks_color_alpha'] ?? '1'))),
+            'ticks_backdrop'          => sanitize_text_field($_POST['ticks_backdrop'] ?? ''),
+            'ticks_backdrop_alpha'    => max(0, min(1, floatval($_POST['ticks_backdrop_alpha'] ?? '1'))),
         ];
         update_option('cdb_grafica_colores', $colores);
         echo '<div class="updated"><p>Colores actualizados.</p></div>';
     }
 
     $defaults = [
-        'bar_background'      => 'rgba(75, 192, 192, 0.2)',
-        'bar_border'          => 'rgba(75, 192, 192, 1)',
-        'empleado_background' => 'rgba(75, 192, 192, 0.2)',
-        'empleado_border'     => 'rgba(75, 192, 192, 1)',
-        'ticks_color'         => '#666666',
-        'ticks_backdrop'      => '',
+        'bar_background'           => '#4bc0c0',
+        'bar_background_alpha'     => 0.2,
+        'bar_border'               => '#4bc0c0',
+        'bar_border_alpha'         => 1,
+        'empleado_background'      => '#4bc0c0',
+        'empleado_background_alpha'=> 0.2,
+        'empleado_border'          => '#4bc0c0',
+        'empleado_border_alpha'    => 1,
+        'ticks_color'              => '#666666',
+        'ticks_color_alpha'        => 1,
+        'ticks_backdrop'           => '',
+        'ticks_backdrop_alpha'     => 1,
     ];
-    $colores = get_option('cdb_grafica_colores', $defaults);
+    $colores = get_option('cdb_grafica_colores', []);
+    $colores = wp_parse_args($colores, $defaults);
+
+    // Compatibilidad con valores antiguos en formato rgba
+    foreach (['bar_background', 'bar_border', 'empleado_background', 'empleado_border', 'ticks_color', 'ticks_backdrop'] as $field) {
+        if (strpos($colores[$field], 'rgb') === 0) {
+            [$hex, $alpha] = cdb_rgba_to_hex_alpha($colores[$field]);
+            $colores[$field] = $hex;
+            $colores[$field . '_alpha'] = $alpha;
+        }
+    }
 
     wp_enqueue_style('wp-color-picker');
     wp_enqueue_script('wp-color-picker');
+
     ?>
     <div class="wrap">
         <h1>Configurar Colores</h1>
@@ -46,34 +78,52 @@ function cdb_grafica_colores_page() {
             <table class="form-table">
                 <tr>
                     <th scope="row">Bar - Color de fondo</th>
-                    <td><input type="text" name="bar_background" value="<?php echo esc_attr($colores['bar_background']); ?>" class="cdb-color-field" /></td>
+                    <td>
+                        <input type="text" name="bar_background" value="<?php echo esc_attr($colores['bar_background']); ?>" class="cdb-color-field" />
+                        <input type="number" step="0.05" min="0" max="1" name="bar_background_alpha" value="<?php echo esc_attr($colores['bar_background_alpha']); ?>" class="small-text" />
+                    </td>
                 </tr>
                 <tr>
                     <th scope="row">Bar - Color de borde</th>
-                    <td><input type="text" name="bar_border" value="<?php echo esc_attr($colores['bar_border']); ?>" class="cdb-color-field" /></td>
+                    <td>
+                        <input type="text" name="bar_border" value="<?php echo esc_attr($colores['bar_border']); ?>" class="cdb-color-field" />
+                        <input type="number" step="0.05" min="0" max="1" name="bar_border_alpha" value="<?php echo esc_attr($colores['bar_border_alpha']); ?>" class="small-text" />
+                    </td>
                 </tr>
                 <tr>
                     <th scope="row">Empleado - Color de fondo</th>
-                    <td><input type="text" name="empleado_background" value="<?php echo esc_attr($colores['empleado_background']); ?>" class="cdb-color-field" /></td>
+                    <td>
+                        <input type="text" name="empleado_background" value="<?php echo esc_attr($colores['empleado_background']); ?>" class="cdb-color-field" />
+                        <input type="number" step="0.05" min="0" max="1" name="empleado_background_alpha" value="<?php echo esc_attr($colores['empleado_background_alpha']); ?>" class="small-text" />
+                    </td>
                 </tr>
                 <tr>
                     <th scope="row">Empleado - Color de borde</th>
-                    <td><input type="text" name="empleado_border" value="<?php echo esc_attr($colores['empleado_border']); ?>" class="cdb-color-field" /></td>
+                    <td>
+                        <input type="text" name="empleado_border" value="<?php echo esc_attr($colores['empleado_border']); ?>" class="cdb-color-field" />
+                        <input type="number" step="0.05" min="0" max="1" name="empleado_border_alpha" value="<?php echo esc_attr($colores['empleado_border_alpha']); ?>" class="small-text" />
+                    </td>
                 </tr>
                 <tr>
                     <th scope="row">Ticks - Color</th>
-                    <td><input type="text" name="ticks_color" value="<?php echo esc_attr($colores['ticks_color']); ?>" class="cdb-color-field" /></td>
+                    <td>
+                        <input type="text" name="ticks_color" value="<?php echo esc_attr($colores['ticks_color']); ?>" class="cdb-color-field" />
+                        <input type="number" step="0.05" min="0" max="1" name="ticks_color_alpha" value="<?php echo esc_attr($colores['ticks_color_alpha']); ?>" class="small-text" />
+                    </td>
                 </tr>
                 <tr>
                     <th scope="row">Ticks - Color de fondo</th>
-                    <td><input type="text" name="ticks_backdrop" value="<?php echo esc_attr($colores['ticks_backdrop']); ?>" class="cdb-color-field" /></td>
+                    <td>
+                        <input type="text" name="ticks_backdrop" value="<?php echo esc_attr($colores['ticks_backdrop']); ?>" class="cdb-color-field" />
+                        <input type="number" step="0.05" min="0" max="1" name="ticks_backdrop_alpha" value="<?php echo esc_attr($colores['ticks_backdrop_alpha']); ?>" class="small-text" />
+                    </td>
                 </tr>
             </table>
             <?php submit_button(); ?>
         </form>
     </div>
     <script>
-    jQuery(document).ready(function($){
+    jQuery(function($){
         $('.cdb-color-field').wpColorPicker();
     });
     </script>

--- a/inc/grafica-bar.php
+++ b/inc/grafica-bar.php
@@ -1,6 +1,21 @@
 <?php
 // inc/grafica-bar.php
 
+function cdb_hex_to_rgba($hex, $alpha = 1) {
+    $hex = ltrim($hex, '#');
+    if (strlen($hex) === 3) {
+        $hex = preg_replace('/(.)/', '$1$1', $hex);
+    }
+    if (strlen($hex) !== 6) {
+        return 'rgba(0,0,0,' . $alpha . ')';
+    }
+    $int = hexdec($hex);
+    $r = ($int >> 16) & 255;
+    $g = ($int >> 8) & 255;
+    $b = $int & 255;
+    return sprintf('rgba(%d, %d, %d, %s)', $r, $g, $b, $alpha);
+}
+
 // ------------------------------------------------------------------
 // 1. Registrar el bloque de gráfica "bar".
 // ------------------------------------------------------------------
@@ -121,16 +136,22 @@ $results = $wpdb->get_results($wpdb->prepare("
 
     // Obtener colores configurados
     $defaults = [
-        'bar_background'      => 'rgba(75, 192, 192, 0.2)',
-        'bar_border'          => 'rgba(75, 192, 192, 1)',
-        'ticks_color'         => '#666666',
-        'ticks_backdrop'      => ''
+        'bar_background'           => '#4bc0c0',
+        'bar_background_alpha'     => 0.2,
+        'bar_border'               => '#4bc0c0',
+        'bar_border_alpha'         => 1,
+        'ticks_color'              => '#666666',
+        'ticks_color_alpha'        => 1,
+        'ticks_backdrop'           => '',
+        'ticks_backdrop_alpha'     => 1,
     ];
-    $opts     = get_option('cdb_grafica_colores', $defaults);
-    $attributes['backgroundColor']   = $opts['bar_background'] ?? $defaults['bar_background'];
-    $attributes['borderColor']       = $opts['bar_border'] ?? $defaults['bar_border'];
-    $attributes['ticksColor']        = $opts['ticks_color'] ?? $defaults['ticks_color'];
-    $attributes['ticksBackdropColor'] = $opts['ticks_backdrop'] ?? $defaults['ticks_backdrop'];
+    $opts = get_option('cdb_grafica_colores', []);
+    $opts = wp_parse_args($opts, $defaults);
+
+    $attributes['backgroundColor']   = cdb_hex_to_rgba($opts['bar_background'], $opts['bar_background_alpha']);
+    $attributes['borderColor']       = cdb_hex_to_rgba($opts['bar_border'], $opts['bar_border_alpha']);
+    $attributes['ticksColor']        = cdb_hex_to_rgba($opts['ticks_color'], $opts['ticks_color_alpha']);
+    $attributes['ticksBackdropColor'] = $opts['ticks_backdrop'] === '' ? '' : cdb_hex_to_rgba($opts['ticks_backdrop'], $opts['ticks_backdrop_alpha']);
 
     ob_start();
     ?>

--- a/inc/grafica-empleado.php
+++ b/inc/grafica-empleado.php
@@ -1,6 +1,21 @@
 <?php
 // inc/grafica-empleado.php
 
+function cdb_hex_to_rgba($hex, $alpha = 1) {
+    $hex = ltrim($hex, '#');
+    if (strlen($hex) === 3) {
+        $hex = preg_replace('/(.)/', '$1$1', $hex);
+    }
+    if (strlen($hex) !== 6) {
+        return 'rgba(0,0,0,' . $alpha . ')';
+    }
+    $int = hexdec($hex);
+    $r = ($int >> 16) & 255;
+    $g = ($int >> 8) & 255;
+    $b = $int & 255;
+    return sprintf('rgba(%d, %d, %d, %s)', $r, $g, $b, $alpha);
+}
+
 // ------------------------------------------------------------------
 // 1. Registro del bloque "grafica-empleado".
 // ------------------------------------------------------------------
@@ -96,16 +111,22 @@ function renderizar_bloque_grafica_empleado($attributes, $content) {
 
     // Obtener colores configurados
     $defaults = [
-        'empleado_background' => 'rgba(75, 192, 192, 0.2)',
-        'empleado_border'     => 'rgba(75, 192, 192, 1)',
-        'ticks_color'         => '#666666',
-        'ticks_backdrop'      => ''
+        'empleado_background'           => '#4bc0c0',
+        'empleado_background_alpha'     => 0.2,
+        'empleado_border'               => '#4bc0c0',
+        'empleado_border_alpha'         => 1,
+        'ticks_color'                   => '#666666',
+        'ticks_color_alpha'             => 1,
+        'ticks_backdrop'                => '',
+        'ticks_backdrop_alpha'          => 1,
     ];
-    $opts     = get_option('cdb_grafica_colores', $defaults);
-    $attributes['backgroundColor']   = $opts['empleado_background'] ?? $defaults['empleado_background'];
-    $attributes['borderColor']       = $opts['empleado_border'] ?? $defaults['empleado_border'];
-    $attributes['ticksColor']        = $opts['ticks_color'] ?? $defaults['ticks_color'];
-    $attributes['ticksBackdropColor'] = $opts['ticks_backdrop'] ?? $defaults['ticks_backdrop'];
+    $opts = get_option('cdb_grafica_colores', []);
+    $opts = wp_parse_args($opts, $defaults);
+
+    $attributes['backgroundColor']   = cdb_hex_to_rgba($opts['empleado_background'], $opts['empleado_background_alpha']);
+    $attributes['borderColor']       = cdb_hex_to_rgba($opts['empleado_border'], $opts['empleado_border_alpha']);
+    $attributes['ticksColor']        = cdb_hex_to_rgba($opts['ticks_color'], $opts['ticks_color_alpha']);
+    $attributes['ticksBackdropColor'] = $opts['ticks_backdrop'] === '' ? '' : cdb_hex_to_rgba($opts['ticks_backdrop'], $opts['ticks_backdrop_alpha']);
 
     ob_start();
     ?>


### PR DESCRIPTION
## Summary
- add alpha inputs next to each color field
- fallback to hex+alpha when old rgba values are found
- convert saved colors into RGBA before chart render
- document how the Alpha field works

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885834955e48327b16a236fbeb7f1dd