### PR TITLE
Internationalize admin strings

### DIFF
--- a/admin/modificar_colores.php
+++ b/admin/modificar_colores.php
@@ -3,8 +3,8 @@
 function cdb_grafica_colores_menu() {
     add_submenu_page(
         'cdb_grafica_menu',
-        'Configurar Colores',
-        'Configurar Colores',
+        __( 'Configurar Colores', 'cdb-grafica' ),
+        __( 'Configurar Colores', 'cdb-grafica' ),
         'manage_options',
         'cdb_modificar_colores',
         'cdb_grafica_colores_page'
@@ -23,7 +23,9 @@ function cdb_grafica_colores_page() {
             'ticks_backdrop'      => sanitize_text_field($_POST['ticks_backdrop'] ?? ''),
         ];
         update_option('cdb_grafica_colores', $colores);
-        echo '<div class="updated"><p>Colores actualizados.</p></div>';
+        echo '<div class="updated"><p>'; 
+        esc_html_e( 'Colores actualizados.', 'cdb-grafica' );
+        echo '</p></div>';
     }
 
     $defaults = [
@@ -57,32 +59,32 @@ function cdb_grafica_colores_page() {
     );
     ?>
     <div class="wrap">
-        <h1>Configurar Colores</h1>
+        <h1><?php esc_html_e( 'Configurar Colores', 'cdb-grafica' ); ?></h1>
         <form method="post">
             <?php wp_nonce_field('cdb_guardar_colores', 'cdb_grafica_colores_nonce'); ?>
             <table class="form-table">
                 <tr>
-                    <th scope="row">Bar - Color de fondo</th>
+                    <th scope="row"><?php esc_html_e( 'Bar - Color de fondo', 'cdb-grafica' ); ?></th>
                     <td><input type="text" name="bar_background" value="<?php echo esc_attr($colores['bar_background']); ?>" class="cdb-color-field" /></td>
                 </tr>
                 <tr>
-                    <th scope="row">Bar - Color de borde</th>
+                    <th scope="row"><?php esc_html_e( 'Bar - Color de borde', 'cdb-grafica' ); ?></th>
                     <td><input type="text" name="bar_border" value="<?php echo esc_attr($colores['bar_border']); ?>" class="cdb-color-field" /></td>
                 </tr>
                 <tr>
-                    <th scope="row">Empleado - Color de fondo</th>
+                    <th scope="row"><?php esc_html_e( 'Empleado - Color de fondo', 'cdb-grafica' ); ?></th>
                     <td><input type="text" name="empleado_background" value="<?php echo esc_attr($colores['empleado_background']); ?>" class="cdb-color-field" /></td>
                 </tr>
                 <tr>
-                    <th scope="row">Empleado - Color de borde</th>
+                    <th scope="row"><?php esc_html_e( 'Empleado - Color de borde', 'cdb-grafica' ); ?></th>
                     <td><input type="text" name="empleado_border" value="<?php echo esc_attr($colores['empleado_border']); ?>" class="cdb-color-field" /></td>
                 </tr>
                 <tr>
-                    <th scope="row">Ticks - Color</th>
+                    <th scope="row"><?php esc_html_e( 'Ticks - Color', 'cdb-grafica' ); ?></th>
                     <td><input type="text" name="ticks_color" value="<?php echo esc_attr($colores['ticks_color']); ?>" class="cdb-color-field" /></td>
                 </tr>
                 <tr>
-                    <th scope="row">Ticks - Color de fondo</th>
+                    <th scope="row"><?php esc_html_e( 'Ticks - Color de fondo', 'cdb-grafica' ); ?></th>
                     <td><input type="text" name="ticks_backdrop" value="<?php echo esc_attr($colores['ticks_backdrop']); ?>" class="cdb-color-field" /></td>
                 </tr>
             </table>

--- a/admin/modificar_criterios.php
+++ b/admin/modificar_criterios.php
@@ -2,8 +2,8 @@
 // Agregar el menú principal del plugin en el panel de administración
 function cdb_grafica_menu() {
     add_menu_page(
-        'CdB Gráfica',
-        'CdB Gráfica',
+        __( 'CdB Gráfica', 'cdb-grafica' ),
+        __( 'CdB Gráfica', 'cdb-grafica' ),
         'manage_options',
         'cdb_grafica_menu',
         'cdb_grafica_dashboard_page',
@@ -17,8 +17,8 @@ add_action('admin_menu', 'cdb_grafica_menu');
 function cdb_grafica_dashboard_page() {
     ?>
     <div class="wrap">
-        <h1>Bienvenido a CdB Gráfica</h1>
-        <p>Desde este panel puedes gestionar las gráficas y modificar los criterios evaluativos.</p>
+        <h1><?php esc_html_e( 'Bienvenido a CdB Gráfica', 'cdb-grafica' ); ?></h1>
+        <p><?php esc_html_e( 'Desde este panel puedes gestionar las gráficas y modificar los criterios evaluativos.', 'cdb-grafica' ); ?></p>
     </div>
     <?php
 }
@@ -27,8 +27,8 @@ function cdb_grafica_dashboard_page() {
 function cdb_grafica_modificar_criterios_menu() {
     add_submenu_page(
         'cdb_grafica_menu',
-        'Modificar Criterios',
-        'Modificar Criterios',
+        __( 'Modificar Criterios', 'cdb-grafica' ),
+        __( 'Modificar Criterios', 'cdb-grafica' ),
         'manage_options',
         'cdb_modificar_criterios',
         'cdb_grafica_modificar_criterios_page'
@@ -42,22 +42,22 @@ function cdb_grafica_modificar_criterios_page() {
     $criterios = cdb_grafica_get_criterios_organizados($tab);
     ?>
     <div class="wrap">
-        <h1>Modificar Criterios</h1>
+        <h1><?php esc_html_e( 'Modificar Criterios', 'cdb-grafica' ); ?></h1>
         <h2 class="nav-tab-wrapper">
-            <a href="?page=cdb_modificar_criterios&tab=bar" class="nav-tab <?php echo ($tab == 'bar') ? 'nav-tab-active' : ''; ?>">Bar</a>
-            <a href="?page=cdb_modificar_criterios&tab=empleado" class="nav-tab <?php echo ($tab == 'empleado') ? 'nav-tab-active' : ''; ?>">Empleado</a>
+            <a href="?page=cdb_modificar_criterios&tab=bar" class="nav-tab <?php echo ($tab == 'bar') ? 'nav-tab-active' : ''; ?>"><?php esc_html_e( 'Bar', 'cdb-grafica' ); ?></a>
+            <a href="?page=cdb_modificar_criterios&tab=empleado" class="nav-tab <?php echo ($tab == 'empleado') ? 'nav-tab-active' : ''; ?>"><?php esc_html_e( 'Empleado', 'cdb-grafica' ); ?></a>
         </h2>
         <form method="post" action="">
             <table class="form-table">
                 <tr>
-                    <th><label for="criterio_actual">Criterio a Reemplazar:</label></th>
+                    <th><label for="criterio_actual"><?php esc_html_e( 'Criterio a Reemplazar:', 'cdb-grafica' ); ?></label></th>
                     <td>
                         <select name="criterio_actual" id="criterio_actual">
                             <?php foreach ($criterios as $grupo => $items) { ?>
-                                <optgroup label="<?php echo esc_attr($grupo); ?>">
+                                <optgroup label="<?php echo esc_attr__( $grupo, 'cdb-grafica' ); ?>">
                                     <?php foreach ($items as $criterio) { ?>
-                                        <option value="<?php echo esc_attr($criterio); ?>">
-                                            <?php echo esc_html($criterio); ?>
+                                        <option value="<?php echo esc_attr( $criterio ); ?>">
+                                            <?php echo esc_html__( $criterio, 'cdb-grafica' ); ?>
                                         </option>
                                     <?php } ?>
                                 </optgroup>

--- a/cdb-grafica.php
+++ b/cdb-grafica.php
@@ -59,7 +59,7 @@ function cdb_obtener_grafica() {
     $type = isset($_POST['type']) ? sanitize_text_field($_POST['type']) : '';
 
     if (!$type || !in_array($type, ['bar', 'empleado'])) {
-        wp_send_json_error(['message' => 'Tipo inválido.']);
+        wp_send_json_error(['message' => __( 'Tipo inválido.', 'cdb-grafica' )]);
         return;
     }
 
@@ -71,7 +71,7 @@ function cdb_obtener_grafica() {
     $results = $wpdb->get_results($query, ARRAY_A);
 
     if (empty($results)) {
-        wp_send_json_error(['message' => 'No se encontraron datos.']);
+        wp_send_json_error(['message' => __( 'No se encontraron datos.', 'cdb-grafica' )]);
         return;
     }
 

--- a/languages/cdb-grafica.pot
+++ b/languages/cdb-grafica.pot
@@ -1,0 +1,150 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-07-27 10:15+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: inc/grafica-bar.php:237 inc/grafica-empleado.php:216
+msgid "No tienes permisos para enviar resultados."
+msgstr ""
+
+#: inc/grafica-bar.php:249
+msgid "Este contenido no es un bar válido."
+msgstr ""
+
+#: inc/grafica-bar.php:439 inc/grafica-empleado.php:418
+msgid "Nonce inválido."
+msgstr ""
+
+#: inc/grafica-bar.php:442 inc/grafica-empleado.php:421
+msgid "No tienes permisos para realizar esta acción."
+msgstr ""
+
+#: inc/grafica-bar.php:454
+msgid "Bar inválido."
+msgstr ""
+
+#: inc/grafica-bar.php:459
+msgid "No puedes enviar calificaciones a un bar como Empleador."
+msgstr ""
+
+#: inc/grafica-bar.php:466 inc/grafica-bar.php:479
+msgid "No perteneces a ningún equipo de este bar."
+msgstr ""
+
+#: inc/grafica-empleado.php:228
+msgid "Este contenido no es un empleado válido."
+msgstr ""
+
+#: inc/grafica-empleado.php:433
+msgid "Empleado inválido."
+msgstr ""
+
+#: inc/grafica-empleado.php:436
+msgid "No es un post de tipo empleado."
+msgstr ""
+
+#: inc/grafica-empleado.php:443
+msgid "No puedes calificar a tu propio empleado."
+msgstr ""
+
+#: inc/grafica-empleado.php:449
+msgid "No se encontró tu perfil de empleado."
+msgstr ""
+
+#: inc/grafica-empleado.php:464
+msgid "No puedes calificar a un empleado que no pertenece a tu mismo equipo."
+msgstr ""
+
+#: inc/grafica-empleado.php:481
+msgid "No tienes bares para calificar a este empleado."
+msgstr ""
+
+#: inc/grafica-empleado.php:494
+msgid "No pertenece a tu equipo."
+msgstr ""
+
+#: admin/modificar_criterios.php:5 admin/modificar_criterios.php:6
+msgid "CdB Gráfica"
+msgstr ""
+
+#: admin/modificar_criterios.php:20
+msgid "Bienvenido a CdB Gráfica"
+msgstr ""
+
+#: admin/modificar_criterios.php:21
+msgid ""
+"Desde este panel puedes gestionar las gráficas y modificar los criterios "
+"evaluativos."
+msgstr ""
+
+#: admin/modificar_criterios.php:30 admin/modificar_criterios.php:31
+#: admin/modificar_criterios.php:45
+msgid "Modificar Criterios"
+msgstr ""
+
+#: admin/modificar_criterios.php:47
+msgid "Bar"
+msgstr ""
+
+#: admin/modificar_criterios.php:48
+msgid "Empleado"
+msgstr ""
+
+#: admin/modificar_criterios.php:53
+msgid "Criterio a Reemplazar:"
+msgstr ""
+
+#: admin/modificar_colores.php:6 admin/modificar_colores.php:7
+#: admin/modificar_colores.php:62
+msgid "Configurar Colores"
+msgstr ""
+
+#: admin/modificar_colores.php:27
+msgid "Colores actualizados."
+msgstr ""
+
+#: admin/modificar_colores.php:67
+msgid "Bar - Color de fondo"
+msgstr ""
+
+#: admin/modificar_colores.php:71
+msgid "Bar - Color de borde"
+msgstr ""
+
+#: admin/modificar_colores.php:75
+msgid "Empleado - Color de fondo"
+msgstr ""
+
+#: admin/modificar_colores.php:79
+msgid "Empleado - Color de borde"
+msgstr ""
+
+#: admin/modificar_colores.php:83
+msgid "Ticks - Color"
+msgstr ""
+
+#: admin/modificar_colores.php:87
+msgid "Ticks - Color de fondo"
+msgstr ""
+
+#: cdb-grafica.php:62
+msgid "Tipo inválido."
+msgstr ""
+
+#: cdb-grafica.php:74
+msgid "No se encontraron datos."
+msgstr ""


### PR DESCRIPTION
## Summary
- add translations in the color settings admin page
- localize text in admin criteria page
- internationalize ajax messages
- generate translation template

## Testing
- `npm run build` *(fails: `wp-scripts` not found)*
- `php -l admin/modificar_criterios.php`
- `php -l admin/modificar_colores.php`
- `php -l cdb-grafica.php`


------
https://chatgpt.com/codex/tasks/task_e_6885fb6407fc8327a532fde2d79bceb6