### PR TITLE
Fix duplicate RGBA color picker initialization

### DIFF
--- a/admin/modificar_colores.php
+++ b/admin/modificar_colores.php
@@ -94,10 +94,6 @@ function cdb_grafica_colores_page() {
             <?php submit_button(); ?>
         </form>
     </div>
-    <script>
-    jQuery(document).ready(function($){
-        $('.cdb-color-field').rgbaColorPicker();
-    });
-    </script>
     <?php
+    // La inicialización de '.cdb-color-field' se realiza en rgba-color-picker.js
 }


### PR DESCRIPTION
## Summary
- remove manual color picker initialization script

## Testing
- `npm run build` *(fails: `wp-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886081f8e2883279b9858f7bb0d7d8e