### PR TITLE
Add preview table of organized criteria

### DIFF
--- a/admin/modificar_criterios.php
+++ b/admin/modificar_criterios.php
@@ -102,6 +102,23 @@ function cdb_grafica_modificar_criterios_page() {
                 </button>
             </p>
         </form>
+
+        <h2><?php esc_html_e( 'Vista previa de criterios', 'cdb-grafica' ); ?></h2>
+        <table class="widefat fixed" style="max-width:800px">
+            <tbody>
+            <?php $vista = cdb_grafica_get_criterios_organizados( $tab ); ?>
+            <?php foreach ( $vista as $grupo_nombre => $lista ) : ?>
+                <tr>
+                    <th colspan="2"><?php echo esc_html( $grupo_nombre ); ?></th>
+                </tr>
+                <?php foreach ( $lista as $etiqueta ) : ?>
+                    <tr>
+                        <td style="padding-left:20px;"><?php echo esc_html( $etiqueta ); ?></td>
+                    </tr>
+                <?php endforeach; ?>
+            <?php endforeach; ?>
+            </tbody>
+        </table>
     </div>
     <?php
 }


### PR DESCRIPTION
## Summary
- show a preview of criteria groups underneath the editing form
- get ordered criteria via `cdb_grafica_get_criterios_organizados`
- add translation for the new "Vista previa de criterios" heading

## Testing
- `php -l admin/modificar_criterios.php`

------
https://chatgpt.com/codex/tasks/task_e_688616f9312c83278c90a603b7515ce5