### PR TITLE
Use shared criteria helper for front-end forms

### DIFF
--- a/admin/modificar_criterios.php
+++ b/admin/modificar_criterios.php
@@ -107,13 +107,13 @@ function cdb_grafica_modificar_criterios_page() {
         <table class="widefat fixed" style="max-width:800px">
             <tbody>
             <?php $vista = cdb_grafica_get_criterios_organizados( $tab ); ?>
-            <?php foreach ( $vista as $grupo_nombre => $lista ) : ?>
+            <?php foreach ( $vista as $grupo_nombre => $items ) : ?>
                 <tr>
                     <th colspan="2"><?php echo esc_html( $grupo_nombre ); ?></th>
                 </tr>
-                <?php foreach ( $lista as $etiqueta ) : ?>
+                <?php foreach ( $items as $info ) : ?>
                     <tr>
-                        <td style="padding-left:20px;"><?php echo esc_html( $etiqueta ); ?></td>
+                        <td style="padding-left:20px;"><?php echo esc_html( $info['label'] ); ?></td>
                     </tr>
                 <?php endforeach; ?>
             <?php endforeach; ?>
@@ -123,23 +123,7 @@ function cdb_grafica_modificar_criterios_page() {
     <?php
 }
 
-// Definir grupos de criterios reales
-function cdb_grafica_get_criterios_organizados($grafica_tipo) {
-    $option   = 'cdb_grafica_criterios_' . $grafica_tipo;
-    $defaults = cdb_grafica_default_criterios($grafica_tipo);
-    $data     = get_option($option, $defaults);
 
-    $grupos = [];
-    foreach ($data as $grupo) {
-        $lista = [];
-        usort($grupo['criterios'], function($a, $b) { return intval($a['orden']) - intval($b['orden']); });
-        foreach ($grupo['criterios'] as $crit) {
-            $lista[] = $crit['label'];
-        }
-        $grupos[$grupo['grupo']] = $lista;
-    }
-    return $grupos;
-}
 
 function cdb_grafica_default_criterios($tipo) {
     if ($tipo === 'bar') {

--- a/cdb-grafica.php
+++ b/cdb-grafica.php
@@ -25,6 +25,7 @@ add_action( 'plugins_loaded', 'cdb_grafica_load_textdomain' );
 register_activation_hook(__FILE__, 'grafica_bar_create_table');
 register_activation_hook(__FILE__, 'grafica_empleado_create_table');
 register_activation_hook(__FILE__, 'cdb_grafica_init_default_criterios');
+require_once plugin_dir_path(__FILE__) . 'inc/shared-functions.php';
 require_once plugin_dir_path(__FILE__) . 'admin/modificar_criterios.php';
 require_once plugin_dir_path(__FILE__) . 'admin/modificar_colores.php';
 

--- a/inc/grafica-bar.php
+++ b/inc/grafica-bar.php
@@ -2,6 +2,7 @@
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
+require_once plugin_dir_path( __FILE__ ) . 'shared-functions.php';
 // inc/grafica-bar.php
 
 // ------------------------------------------------------------------
@@ -59,33 +60,8 @@ $results = $wpdb->get_results($wpdb->prepare("
     SELECT * FROM $table_name WHERE post_id = %d
 ", $post_id));
 
-    // Inicializar grupos
-    $grupos = [
-        'DIB' => [
-            'relacion_superiores'
-        ],
-        'COE' => [
-            'salario'
-        ],
-        'EDT' => [
-            'espacio_seguro'
-        ],
-        'COL' => [
-            'turnos_justos'
-        ],
-        'EQU' => [
-            'motivacion'
-        ],
-        'ALB' => [
-            'bienvenida'
-        ],
-        'DPF' => [
-            'formacion'
-        ],
-        'CLI' => [
-            'reputacion'
-        ]
-    ];
+    // Obtener grupos de criterios desde la configuración
+    $grupos = cdb_grafica_get_criterios_organizados( 'bar' );
 
     // Etiquetas de la gráfica
     $etiquetas_grafica = array_keys($grupos);
@@ -96,7 +72,7 @@ $results = $wpdb->get_results($wpdb->prepare("
         $total_grupo = 0;
         $count       = 0;
         foreach ($results as $row) {
-            foreach ($campos as $campo) {
+            foreach ( array_keys( $campos ) as $campo ) {
                 // Un valor 0 indica que el criterio no fue valorado y se ignora
                 if (isset($row->$campo) && $row->$campo != 0) {
                     $total_grupo += $row->$campo;
@@ -303,56 +279,7 @@ add_shortcode('grafica_bar_form', function($atts) {
     ), ARRAY_A);
     
     // Definir los nombres y descripciones de las características
-    $grupos = [
-        'DIB (Direccion)' => [
-            'relacion_superiores' => [
-                'label' => 'Relación con Superiores', 
-                'descripcion' => 'Relación de los empleados con los supervisores o gerentes.'
-            ],
-        ],
-        'COE (Condiciones Económicas)' => [
-            'salario' => [
-                'label' => 'Salario', 
-                'descripcion' => 'Adecuación del salario a las funciones desempeñadas.'
-            ],
-        ],
-        'EDT (Espacio de trabajo)' => [
-            'espacio_seguro' => [
-                'label' => 'Espacio Seguro', 
-                'descripcion' => 'Percepción general de seguridad en el lugar de trabajo.'
-            ],
-        ],
-        'COL (Condiciones Laborales)' => [
-            'turnos_justos' => [
-                 'label' => 'Turnos Justos', 
-                'descripcion' => 'Distribución equitativa de turnos laborales entre los empleados.'
-            ],
-        ],
-        'EQU (Equipo)' => [
-            'motivacion' => [
-                'label' => 'Motivación', 
-                'descripcion' => 'Capacidad del equipo para mantener la motivación alta.'
-            ],
-        ],
-        'ALB (Ambiente Laboral)' => [
-            'bienvenida' => [
-                'label' => 'Bienvenida', 
-                'descripcion' => 'Valoración sobre cómo se recibe a los nuevos empleados en el equipo.'
-            ],
-        ],
-        'DPF (Desarrollo Profesional)' => [
-            'formacion' => [
-                'label' => 'Formación', 
-                'descripcion' => 'Oportunidades de capacitación y formación profesional.'
-            ],
-        ],
-        'CLI (Clientela)' => [
-            'reputacion' => [
-                'label' => 'Reputación', 
-                'descripcion' => 'Reputación general del lugar frente a los clientes.'
-            ],
-        ],
-    ];
+    $grupos = cdb_grafica_get_criterios_organizados( 'bar' );
 
 // Encolar estilos y scripts (acordeón, etc.)
     $style_path = plugin_dir_path(dirname(__FILE__)) . 'style.css';

--- a/inc/grafica-empleado.php
+++ b/inc/grafica-empleado.php
@@ -2,6 +2,7 @@
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
+require_once plugin_dir_path( __FILE__ ) . 'shared-functions.php';
 // inc/grafica-empleado.php
 
 // ------------------------------------------------------------------
@@ -53,17 +54,8 @@ function renderizar_bloque_grafica_empleado($attributes, $content) {
         $post_id
     ));
 
-    // Inicializar agrupaciones para calcular promedios
-    $grupos = [
-        'DIE' => ['direccion'],
-        'SAL' => ['camarero'],
-        'TES' => ['venta'],
-        'ATC' => ['satisfaccion'],
-        'TEQ' => ['cooperacion'],
-        'ORL' => ['orden'],
-        'TEC' => ['cocina_local'],
-        'COC' => ['cocinero']
-    ];
+    // Inicializar agrupaciones para calcular promedios desde las opciones
+    $grupos = cdb_grafica_get_criterios_organizados( 'empleado' );
 
     // Calcular promedios por grupo
     $promedios = [];
@@ -71,7 +63,7 @@ function renderizar_bloque_grafica_empleado($attributes, $content) {
         $total_grupo = 0;
         $count = 0;
         foreach ($results as $row) {
-            foreach ($campos as $campo) {
+            foreach ( array_keys( $campos ) as $campo ) {
                 // Un valor 0 significa que el criterio se dejó en blanco y no cuenta
                 if (isset($row->$campo) && $row->$campo != 0) {
                     $total_grupo += $row->$campo;
@@ -315,32 +307,7 @@ if (in_array('empleador', $roles) && $puede_calificar) {
     ), ARRAY_A);
 
     // Definir los nombres y descripciones de las características
-    $grupos = [
-        'DIE (Dirección)' => [
-            'direccion'     => ['label' => 'Dirección',     'descripcion' => 'Guiar al equipo hacia los objetivos comunes.'],
-        ],
-        'SAL (Sala)' => [
-            'camarero'          => ['label' => 'Camarero',                'descripcion' => 'Atender y servir a los clientes en sala.'],
-        ],
-        'TES (Técnica Sala)' => [
-            'venta'        => ['label' => 'Venta',       'descripcion' => 'Capacidades comerciales de venta.'],
-        ],
-        'ATC (Atención al Cliente)' => [
-            'satisfaccion'    => ['label' => 'Satisfacción', 'descripcion' => 'Garantizar una experiencia positiva para el cliente.'],
-        ],
-        'TEQ (Trabajo en Equipo)' => [
-            'cooperacion'   => ['label' => 'Cooperación', 'descripcion' => 'Colaborar para lograr objetivos comunes.'],
-        ],
-        'ORL (Orden y Limpieza)' => [
-            'orden'            => ['label' => 'Orden',         'descripcion' => 'Organizar el espacio y tareas de forma eficiente.'],
-        ],
-        'TEC (Técnica de Cocina)' => [
-            'cocina_local'       => ['label' => 'Cocina Local',       'descripcion' => 'Dominar técnicas culinarias locales.'],
-        ],
-        'COC (Cocina)' => [
-            'cocinero'            => ['label' => 'Cocinero',                 'descripcion' => 'Encargarse de la preparación de platos principales.'],
-        ],
-    ];
+    $grupos = cdb_grafica_get_criterios_organizados( 'empleado' );
 
     // Encolar estilos y scripts si quieres
     $style_path = plugin_dir_path(dirname(__FILE__)) . 'style.css';

--- a/inc/shared-functions.php
+++ b/inc/shared-functions.php
@@ -49,3 +49,34 @@ function cdb_inyectar_formulario_y_grafica( $content ) {
     return $content;
 }
 add_filter( 'the_content', 'cdb_inyectar_formulario_y_grafica' );
+
+/**
+ * Obtiene los criterios organizados por grupo para el tipo de gráfica
+ * indicado. Devuelve una matriz donde cada grupo contiene los slugs de
+ * los criterios junto con su etiqueta y descripción.
+ *
+ * @param string $grafica_tipo Tipo de gráfica ('bar' o 'empleado').
+ * @return array[] Array asociativo de grupos y criterios.
+ */
+function cdb_grafica_get_criterios_organizados( $grafica_tipo ) {
+    $option   = 'cdb_grafica_criterios_' . $grafica_tipo;
+    $defaults = cdb_grafica_default_criterios( $grafica_tipo );
+    $data     = get_option( $option, $defaults );
+
+    $grupos = [];
+    foreach ( $data as $grupo ) {
+        $lista = [];
+        usort( $grupo['criterios'], function ( $a, $b ) {
+            return intval( $a['orden'] ) - intval( $b['orden'] );
+        } );
+        foreach ( $grupo['criterios'] as $crit ) {
+            $lista[ $crit['slug'] ] = [
+                'label'       => $crit['label'],
+                'descripcion' => $crit['descripcion'],
+            ];
+        }
+        $grupos[ $grupo['grupo'] ] = $lista;
+    }
+
+    return $grupos;
+}


### PR DESCRIPTION
## Summary
- centralize `cdb_grafica_get_criterios_organizados` in `inc/shared-functions.php`
- load shared helper in main plugin file and front-end modules
- use dynamic groups in bar and empleado blocks and forms
- update admin preview table to work with new helper

## Testing
- `npm run build` *(fails: wp-scripts not found)*
- `php -l inc/shared-functions.php`
- `php -l inc/grafica-bar.php`
- `php -l inc/grafica-empleado.php`
- `php -l admin/modificar_criterios.php`
- `php -l cdb-grafica.php`


------
https://chatgpt.com/codex/tasks/task_e_68861949148883279f1f6c58c24dff57