### PR TITLE
Use $wpdb prefix for experiencia queries

### DIFF
--- a/inc/grafica-bar.php
+++ b/inc/grafica-bar.php
@@ -278,7 +278,7 @@ add_shortcode('grafica_bar_form', function($atts) {
         global $wpdb;
         $existe_relacion = $wpdb->get_var($wpdb->prepare("
             SELECT 1
-            FROM wp_cdb_experiencia
+            FROM {$wpdb->prefix}cdb_experiencia
             WHERE empleado_id = %d
               AND bar_id = %d
             LIMIT 1
@@ -480,7 +480,7 @@ if (in_array('empleado', $roles)) {
     // Revisar en wp_cdb_experiencia si el empleado está asociado a este bar
     $existe_relacion = $wpdb->get_var($wpdb->prepare("
         SELECT 1
-        FROM wp_cdb_experiencia
+        FROM {$wpdb->prefix}cdb_experiencia
         WHERE empleado_id = %d
           AND bar_id = %d
         LIMIT 1

--- a/inc/grafica-empleado.php
+++ b/inc/grafica-empleado.php
@@ -255,8 +255,8 @@ if (in_array('empleado', $roles)) {
             // Consulta: ¿existe un equipo_id compartido entre "mi_empleado_id" y "$post_id" en wp_cdb_experiencia?
             $existe_equipo_compartido = $wpdb->get_var($wpdb->prepare("
                 SELECT 1
-                FROM wp_cdb_experiencia e1
-                JOIN wp_cdb_experiencia e2 
+                FROM {$wpdb->prefix}cdb_experiencia e1
+                JOIN {$wpdb->prefix}cdb_experiencia e2 
                       ON e1.equipo_id = e2.equipo_id
                 WHERE e1.empleado_id = %d
                   AND e2.empleado_id = %d
@@ -293,7 +293,7 @@ if (in_array('empleador', $roles) && $puede_calificar) {
         // ¿El empleado (post_id) tiene experiencia en alguno de esos bares?
         $existe_relacion = $wpdb->get_var($wpdb->prepare("
             SELECT 1
-            FROM wp_cdb_experiencia
+            FROM {$wpdb->prefix}cdb_experiencia
             WHERE empleado_id = %d
               AND bar_id IN ($in_bares)
             LIMIT 1
@@ -463,8 +463,8 @@ if (in_array('empleado', $roles)) {
     // Consulta: ¿existe un equipo_id compartido entre "mi_empleado_id" y "$post_id" en wp_cdb_experiencia?
     $existe_equipo_compartido = $wpdb->get_var($wpdb->prepare("
         SELECT 1
-        FROM wp_cdb_experiencia e1
-        JOIN wp_cdb_experiencia e2 
+        FROM {$wpdb->prefix}cdb_experiencia e1
+        JOIN {$wpdb->prefix}cdb_experiencia e2 
               ON e1.equipo_id = e2.equipo_id
         WHERE e1.empleado_id = %d
           AND e2.empleado_id = %d
@@ -495,7 +495,7 @@ if (in_array('empleador', $roles)) {
 
         $existe_relacion = $wpdb->get_var($wpdb->prepare("
             SELECT 1
-            FROM wp_cdb_experiencia
+            FROM {$wpdb->prefix}cdb_experiencia
             WHERE empleado_id = %d
               AND bar_id IN ($in_bares)
             LIMIT 1


### PR DESCRIPTION
## Summary
- use table prefix in experiencia queries for bar and empleado graphics

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68863f14e7f483279368a21bf3dde3df