### PR TITLE
Update Bar submission to ignore auto fields

### DIFF
--- a/inc/grafica-bar.php
+++ b/inc/grafica-bar.php
@@ -497,6 +497,9 @@ if (in_array('empleado', $roles)) {
         $data   = ['post_id' => $post_id, 'user_id' => $user_id];
         $fields = $wpdb->get_col("SHOW COLUMNS FROM $table_name");
         foreach ($fields as $field) {
+            if ($field === 'id' || $field === 'created_at') {
+                continue; // Ignore auto fields
+            }
             if (isset($_POST[$field])) {
                 $data[$field] = floatval($_POST[$field]);
             }


### PR DESCRIPTION
## Summary
- skip `id` and `created_at` columns when building the data array in `handle_grafica_bar_submission`

## Testing
- `php -l inc/grafica-bar.php`
- `php -l inc/grafica-empleado.php`


------
https://chatgpt.com/codex/tasks/task_e_688647beb9ec8327a45494e1eb26b73a