### PR TITLE
Load Chart.js only when graphs are present

### DIFF
--- a/cdb-grafica.php
+++ b/cdb-grafica.php
@@ -87,3 +87,40 @@ function cdb_obtener_grafica() {
     // Enviar los datos en formato JSON
     wp_send_json_success(['data' => $results]);
 }
+
+/**
+ * Enqueue Chart.js only when a graph block or shortcode is present.
+ */
+function cdb_grafica_enqueue_chartjs() {
+    if ( is_admin() ) {
+        return;
+    }
+
+    $enqueue = false;
+
+    if ( is_singular() ) {
+        global $post;
+        $content = $post ? $post->post_content : '';
+
+        if ( has_shortcode( $content, 'grafica_bar' ) || has_shortcode( $content, 'grafica_empleado' ) ) {
+            $enqueue = true;
+        }
+
+        if ( function_exists( 'has_block' ) ) {
+            if ( has_block( 'cdb/grafica-bar', $post ) || has_block( 'cdb/grafica-empleado', $post ) ) {
+                $enqueue = true;
+            }
+        }
+    }
+
+    if ( $enqueue ) {
+        wp_enqueue_script(
+            'chartjs',
+            'https://cdn.jsdelivr.net/npm/chart.js@4.3.0/dist/chart.umd.min.js',
+            [],
+            '4.3.0',
+            false
+        );
+    }
+}
+add_action( 'wp_enqueue_scripts', 'cdb_grafica_enqueue_chartjs' );


### PR DESCRIPTION
## Summary
- enqueue Chart.js in header when a graph block or shortcode is detected

## Testing
- `npm run build` *(fails: wp-scripts not found)*
- `npm ci` *(fails: cannot reach registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68865a323e508327a98e9315cd4d3c3a