### PR TITLE
Add warnings when missing employee function

### DIFF
--- a/inc/grafica-bar.php
+++ b/inc/grafica-bar.php
@@ -267,7 +267,7 @@ add_shortcode('grafica_bar_form', function($atts) {
     if ( function_exists( 'cdb_obtener_empleado_id' ) ) {
         $mi_empleado_id = cdb_obtener_empleado_id( $user_id );
     } else {
-        return;
+        return '<p>' . esc_html__( 'Required function cdb_obtener_empleado_id is missing.', 'cdb-grafica' ) . '</p>';
     }
     if (!$mi_empleado_id) {
         $puede_calificar = false;
@@ -471,7 +471,7 @@ if (in_array('empleado', $roles)) {
     if ( function_exists( 'cdb_obtener_empleado_id' ) ) {
         $mi_empleado_id = cdb_obtener_empleado_id( $user_id );
     } else {
-        return;
+        return '<p>' . esc_html__( 'Required function cdb_obtener_empleado_id is missing.', 'cdb-grafica' ) . '</p>';
     }
     if (!$mi_empleado_id) {
         wp_die( esc_html__( 'No perteneces a ningún equipo de este bar.', 'cdb-grafica' ) );

--- a/inc/grafica-empleado.php
+++ b/inc/grafica-empleado.php
@@ -246,7 +246,7 @@ if (in_array('empleado', $roles)) {
         if ( function_exists( 'cdb_obtener_empleado_id' ) ) {
             $mi_empleado_id = cdb_obtener_empleado_id( $user_id );
         } else {
-            return;
+            return '<p>' . esc_html__( 'Required function cdb_obtener_empleado_id is missing.', 'cdb-grafica' ) . '</p>';
         }
         if (!$mi_empleado_id) {
             $puede_calificar = false;
@@ -454,7 +454,7 @@ if (in_array('empleado', $roles)) {
     if ( function_exists( 'cdb_obtener_empleado_id' ) ) {
         $mi_empleado_id = cdb_obtener_empleado_id( $user_id );
     } else {
-        return;
+        return '<p>' . esc_html__( 'Required function cdb_obtener_empleado_id is missing.', 'cdb-grafica' ) . '</p>';
     }
     if (!$mi_empleado_id) {
         wp_die( esc_html__( 'No se encontró tu perfil de empleado.', 'cdb-grafica' ) );


### PR DESCRIPTION
## Summary
- show missing function warnings when cdb_obtener_empleado_id doesn't exist

## Testing
- `bash setup.sh` *(fails: 403 Forbidden during npm install)*
- `php -l inc/grafica-bar.php`
- `php -l inc/grafica-empleado.php`


------
https://chatgpt.com/codex/tasks/task_e_68865f919bf8832797640f1793cbe76b