### PR TITLE
Centralize criteria definitions

### DIFF
--- a/admin/modificar_criterios.php
+++ b/admin/modificar_criterios.php
@@ -76,31 +76,10 @@ function cdb_grafica_modificar_criterios_page() {
 
 // Definir grupos de criterios reales
 function cdb_grafica_get_criterios_organizados($grafica_tipo) {
-    global $wpdb;
     if ($grafica_tipo === 'bar') {
-        $grupos = [
-            'ALB (Ambiente Laboral Básico)' => ['bienvenida', 'companerismo', 'clima_positivo', 'resolucion_de_conflictos', 'cooperacion', 'relacion_superiores', 'inclusion', 'comunicacion', 'reconocimiento', 'celebracion_logros'],
-            'EDT (Estructura del Trabajo)' => ['tamano', 'cooperacion_edt', 'comunicacion_edt', 'roles_definidos', 'actitud', 'equilibrio', 'socializacion', 'diversidad', 'compromiso', 'sinergia'],
-            'DPF (Desarrollo Profesional)' => ['formacion', 'habilidades', 'cursos', 'promociones', 'eventos', 'networking', 'creatividad', 'mentor', 'innovacion', 'retos'],
-            'CLB (Condiciones Laborales)' => ['turnos_justos', 'descansos', 'normativas', 'flexibilidad', 'dias_libres', 'festivos_remunerados', 'incentivos', 'seguro_medico', 'uniformes', 'estabilidad'],
-            'AEC (Aspectos Económicos)' => ['salario', 'propinas', 'bonos', 'incrementos', 'beneficios', 'extras_remuneradas', 'comisiones', 'incentivos_festivos', 'sostenibilidad_economica', 'cumplimiento'],
-            'EDG (Efectividad del Grupo)' => ['liderazgo', 'justicia', 'motivacion', 'claridad', 'feedback', 'escucha_activa', 'planificacion', 'delegacion', 'participacion', 'resolucion_rapida'],
-            'TBC (Trabajo con Clientes)' => ['volumen', 'clientela', 'estilo', 'menu', 'reputacion', 'organizacion', 'horarios_pico', 'tematica', 'exigencia', 'adaptacion_cultural'],
-            'SGD (Seguridad en el Trabajo)' => ['limpieza', 'botiquin', 'normativas_claras', 'ergonomia', 'prevencion', 'emergencias', 'iluminacion', 'climatizacion', 'senalizacion', 'espacio_seguro']
-        ];
+        return cdb_get_bar_criterios();
     } elseif ($grafica_tipo === 'empleado') {
-        $grupos = [
-            'LID (Liderazgo)' => ['motivacion', 'resolucion', 'organizacion', 'delegacion', 'decision', 'direccion', 'evaluacion', 'planificacion', 'control', 'empatia'],
-            'CLI (Cliente)' => ['cordialidad', 'escucha', 'resolutivo', 'memoria', 'empatia_cli', 'satisfaccion', 'claridad', 'gestion', 'adaptacion', 'fidelidad'],
-            'TEC (Técnica)' => ['menu', 'ingredientes', 'cocteleria', 'vinos', 'cafeteria', 'recomendacion', 'prueba', 'cata', 'protocolo', 'presentacion'],
-            'RAP (Rapidez)' => ['agilidad', 'velocidad', 'montaje', 'reaccion', 'prevision', 'sincronizacion', 'ordenacion', 'imprevistos', 'carga', 'rendimiento'],
-            'ORD (Orden)' => ['limpieza', 'higiene', 'almacenaje', 'productos', 'desinfeccion', 'reabastecimiento', 'clasificacion', 'cuidado', 'reciclaje', 'preparacion'],
-            'EQU (Equipo)' => ['cooperacion', 'interaccion', 'soporte', 'instruccion', 'versatilidad', 'conciliacion', 'fluidez', 'proactividad', 'optimismo', 'adaptabilidad'],
-            'CRE (Creatividad)' => ['originalidad', 'propuestas', 'variedad', 'estilo', 'eventos', 'promocion', 'carta', 'sorpresa', 'diferencia', 'innovacion'],
-            'PRO (Profesionalismo)' => ['puntualidad', 'serenidad', 'educacion', 'apariencia', 'integridad', 'feedback', 'compromiso', 'crecimiento', 'disciplina', 'vocacion']
-        ];
-    } else {
-        $grupos = [];
+        return cdb_get_empleado_criterios();
     }
-    return $grupos;
+    return [];
 }

--- a/cdb-grafica.php
+++ b/cdb-grafica.php
@@ -26,6 +26,7 @@ register_activation_hook(__FILE__, 'grafica_bar_create_table');
 register_activation_hook(__FILE__, 'grafica_empleado_create_table');
 require_once plugin_dir_path(__FILE__) . 'admin/modificar_criterios.php';
 require_once plugin_dir_path(__FILE__) . 'admin/modificar_colores.php';
+require_once __DIR__ . '/inc/criterios.php';
 
 
 // Requerir archivos de CPT y gráficas

--- a/inc/criterios.php
+++ b/inc/criterios.php
@@ -1,0 +1,40 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Devuelve los criterios y grupos para la gráfica de bares.
+ *
+ * @return array
+ */
+function cdb_get_bar_criterios() {
+    return [
+        'ALB (Ambiente Laboral Básico)' => ['bienvenida', 'companerismo', 'clima_positivo', 'resolucion_de_conflictos', 'cooperacion', 'relacion_superiores', 'inclusion', 'comunicacion', 'reconocimiento', 'celebracion_logros'],
+        'EDT (Estructura del Trabajo)'   => ['tamano', 'cooperacion_edt', 'comunicacion_edt', 'roles_definidos', 'actitud', 'equilibrio', 'socializacion', 'diversidad', 'compromiso', 'sinergia'],
+        'DPF (Desarrollo Profesional)'   => ['formacion', 'habilidades', 'cursos', 'promociones', 'eventos', 'networking', 'creatividad', 'mentor', 'innovacion', 'retos'],
+        'CLB (Condiciones Laborales)'    => ['turnos_justos', 'descansos', 'normativas', 'flexibilidad', 'dias_libres', 'festivos_remunerados', 'incentivos', 'seguro_medico', 'uniformes', 'estabilidad'],
+        'AEC (Aspectos Económicos)'      => ['salario', 'propinas', 'bonos', 'incrementos', 'beneficios', 'extras_remuneradas', 'comisiones', 'incentivos_festivos', 'sostenibilidad_economica', 'cumplimiento'],
+        'EDG (Efectividad del Grupo)'    => ['liderazgo', 'justicia', 'motivacion', 'claridad', 'feedback', 'escucha_activa', 'planificacion', 'delegacion', 'participacion', 'resolucion_rapida'],
+        'TBC (Trabajo con Clientes)'     => ['volumen', 'clientela', 'estilo', 'menu', 'reputacion', 'organizacion', 'horarios_pico', 'tematica', 'exigencia', 'adaptacion_cultural'],
+        'SGD (Seguridad en el Trabajo)'  => ['limpieza', 'botiquin', 'normativas_claras', 'ergonomia', 'prevencion', 'emergencias', 'iluminacion', 'climatizacion', 'senalizacion', 'espacio_seguro'],
+    ];
+}
+
+/**
+ * Devuelve los criterios y grupos para la gráfica de empleados.
+ *
+ * @return array
+ */
+function cdb_get_empleado_criterios() {
+    return [
+        'LID (Liderazgo)'    => ['motivacion', 'resolucion', 'organizacion', 'delegacion', 'decision', 'direccion', 'evaluacion', 'planificacion', 'control', 'empatia'],
+        'CLI (Cliente)'      => ['cordialidad', 'escucha', 'resolutivo', 'memoria', 'empatia_cli', 'satisfaccion', 'claridad', 'gestion', 'adaptacion', 'fidelidad'],
+        'TEC (Técnica)'      => ['menu', 'ingredientes', 'cocteleria', 'vinos', 'cafeteria', 'recomendacion', 'prueba', 'cata', 'protocolo', 'presentacion'],
+        'RAP (Rapidez)'      => ['agilidad', 'velocidad', 'montaje', 'reaccion', 'prevision', 'sincronizacion', 'ordenacion', 'imprevistos', 'carga', 'rendimiento'],
+        'ORD (Orden)'        => ['limpieza', 'higiene', 'almacenaje', 'productos', 'desinfeccion', 'reabastecimiento', 'clasificacion', 'cuidado', 'reciclaje', 'preparacion'],
+        'EQU (Equipo)'       => ['cooperacion', 'interaccion', 'soporte', 'instruccion', 'versatilidad', 'conciliacion', 'fluidez', 'proactividad', 'optimismo', 'adaptabilidad'],
+        'CRE (Creatividad)'  => ['originalidad', 'propuestas', 'variedad', 'estilo', 'eventos', 'promocion', 'carta', 'sorpresa', 'diferencia', 'innovacion'],
+        'PRO (Profesionalismo)' => ['puntualidad', 'serenidad', 'educacion', 'apariencia', 'integridad', 'feedback', 'compromiso', 'crecimiento', 'disciplina', 'vocacion'],
+    ];
+}

--- a/inc/grafica-bar.php
+++ b/inc/grafica-bar.php
@@ -59,33 +59,8 @@ $results = $wpdb->get_results($wpdb->prepare("
     SELECT * FROM $table_name WHERE post_id = %d
 ", $post_id));
 
-    // Inicializar grupos
-    $grupos = [
-        'DIB' => [
-            'relacion_superiores'
-        ],
-        'COE' => [
-            'salario'
-        ],
-        'EDT' => [
-            'espacio_seguro'
-        ],
-        'COL' => [
-            'turnos_justos'
-        ],
-        'EQU' => [
-            'motivacion'
-        ],
-        'ALB' => [
-            'bienvenida'
-        ],
-        'DPF' => [
-            'formacion'
-        ],
-        'CLI' => [
-            'reputacion'
-        ]
-    ];
+    // Obtener grupos y criterios definitivos
+    $grupos = cdb_get_bar_criterios();
 
     // Etiquetas de la gráfica
     $etiquetas_grafica = array_keys($grupos);

--- a/inc/grafica-empleado.php
+++ b/inc/grafica-empleado.php
@@ -53,17 +53,8 @@ function renderizar_bloque_grafica_empleado($attributes, $content) {
         $post_id
     ));
 
-    // Inicializar agrupaciones para calcular promedios
-    $grupos = [
-        'DIE' => ['direccion'],
-        'SAL' => ['camarero'],
-        'TES' => ['venta'],
-        'ATC' => ['satisfaccion'],
-        'TEQ' => ['cooperacion'],
-        'ORL' => ['orden'],
-        'TEC' => ['cocina_local'],
-        'COC' => ['cocinero']
-    ];
+    // Obtener grupos y criterios definitivos
+    $grupos = cdb_get_empleado_criterios();
 
     // Calcular promedios por grupo
     $promedios = [];


### PR DESCRIPTION
## Summary
- store bar and employee criteria arrays in new `inc/criterios.php`
- load `inc/criterios.php` from main plugin file
- use helper functions in bar and employee graph code
- reuse helper in admin criteria page

## Testing
- `php -l inc/criterios.php`
- `php -l inc/grafica-bar.php`
- `php -l inc/grafica-empleado.php`
- `php -l admin/modificar_criterios.php`


------
https://chatgpt.com/codex/tasks/task_e_6886a1ba7f48832783751a6e73394155