### PR TITLE
Refactor employee criteria

### DIFF
--- a/admin/modificar_criterios.php
+++ b/admin/modificar_criterios.php
@@ -76,13 +76,19 @@ function cdb_grafica_modificar_criterios_page() {
 
 // Definir grupos de criterios reales
 function cdb_grafica_get_criterios_organizados($grafica_tipo) {
-    global $wpdb;
     if ($grafica_tipo === 'bar') {
         $grupos = [
                     ];
     } elseif ($grafica_tipo === 'empleado') {
-        $grupos = [
-                    ];
+        $criterios = cdb_get_criterios_empleado();
+        $grupos    = [];
+        foreach ($criterios as $grupo => $items) {
+            $labels = [];
+            foreach ($items as $info) {
+                $labels[] = $info['label'];
+            }
+            $grupos[$grupo] = $labels;
+        }
     } else {
         $grupos = [];
     }

--- a/cdb-grafica.php
+++ b/cdb-grafica.php
@@ -30,6 +30,7 @@ require_once plugin_dir_path(__FILE__) . 'admin/modificar_colores.php';
 
 // Requerir archivos de CPT y gráficas
 require_once __DIR__ . '/inc/grafica-bar.php';
+require_once __DIR__ . '/inc/criterios-empleado.php';
 require_once __DIR__ . '/inc/grafica-empleado.php';
 // require_once __DIR__ . '/inc/shared-functions.php';
 

--- a/inc/criterios-empleado.php
+++ b/inc/criterios-empleado.php
@@ -1,0 +1,57 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+function cdb_get_criterios_empleado() {
+    return [
+        'DIE (Dirección)' => [
+            'direccion' => [
+                'label' => 'Dirección',
+                'descripcion' => 'Guiar al equipo hacia los objetivos comunes.'
+            ],
+        ],
+        'SAL (Sala)' => [
+            'camarero' => [
+                'label' => 'Camarero',
+                'descripcion' => 'Atender y servir a los clientes en sala.'
+            ],
+        ],
+        'TES (Técnica Sala)' => [
+            'venta' => [
+                'label' => 'Venta',
+                'descripcion' => 'Capacidades comerciales de venta.'
+            ],
+        ],
+        'ATC (Atención al Cliente)' => [
+            'satisfaccion' => [
+                'label' => 'Satisfacción',
+                'descripcion' => 'Garantizar una experiencia positiva para el cliente.'
+            ],
+        ],
+        'TEQ (Trabajo en Equipo)' => [
+            'cooperacion' => [
+                'label' => 'Cooperación',
+                'descripcion' => 'Colaborar para lograr objetivos comunes.'
+            ],
+        ],
+        'ORL (Orden y Limpieza)' => [
+            'orden' => [
+                'label' => 'Orden',
+                'descripcion' => 'Organizar el espacio y tareas de forma eficiente.'
+            ],
+        ],
+        'TEC (Técnica de Cocina)' => [
+            'cocina_local' => [
+                'label' => 'Cocina Local',
+                'descripcion' => 'Dominar técnicas culinarias locales.'
+            ],
+        ],
+        'COC (Cocina)' => [
+            'cocinero' => [
+                'label' => 'Cocinero',
+                'descripcion' => 'Encargarse de la preparación de platos principales.'
+            ],
+        ],
+    ];
+}

--- a/inc/grafica-empleado.php
+++ b/inc/grafica-empleado.php
@@ -54,16 +54,11 @@ function renderizar_bloque_grafica_empleado($attributes, $content) {
     ));
 
     // Inicializar agrupaciones para calcular promedios
-    $grupos = [
-        'DIE' => ['direccion'],
-        'SAL' => ['camarero'],
-        'TES' => ['venta'],
-        'ATC' => ['satisfaccion'],
-        'TEQ' => ['cooperacion'],
-        'ORL' => ['orden'],
-        'TEC' => ['cocina_local'],
-        'COC' => ['cocinero']
-    ];
+    $criterios = cdb_get_criterios_empleado();
+    $grupos    = [];
+    foreach ($criterios as $grupo_nombre => $campos) {
+        $grupos[$grupo_nombre] = array_keys($campos);
+    }
 
     // Calcular promedios por grupo
     $promedios = [];
@@ -315,32 +310,7 @@ if (in_array('empleador', $roles) && $puede_calificar) {
     ), ARRAY_A);
 
     // Definir los nombres y descripciones de las características
-    $grupos = [
-        'DIE (Dirección)' => [
-            'direccion'     => ['label' => 'Dirección',     'descripcion' => 'Guiar al equipo hacia los objetivos comunes.'],
-        ],
-        'SAL (Sala)' => [
-            'camarero'          => ['label' => 'Camarero',                'descripcion' => 'Atender y servir a los clientes en sala.'],
-        ],
-        'TES (Técnica Sala)' => [
-            'venta'        => ['label' => 'Venta',       'descripcion' => 'Capacidades comerciales de venta.'],
-        ],
-        'ATC (Atención al Cliente)' => [
-            'satisfaccion'    => ['label' => 'Satisfacción', 'descripcion' => 'Garantizar una experiencia positiva para el cliente.'],
-        ],
-        'TEQ (Trabajo en Equipo)' => [
-            'cooperacion'   => ['label' => 'Cooperación', 'descripcion' => 'Colaborar para lograr objetivos comunes.'],
-        ],
-        'ORL (Orden y Limpieza)' => [
-            'orden'            => ['label' => 'Orden',         'descripcion' => 'Organizar el espacio y tareas de forma eficiente.'],
-        ],
-        'TEC (Técnica de Cocina)' => [
-            'cocina_local'       => ['label' => 'Cocina Local',       'descripcion' => 'Dominar técnicas culinarias locales.'],
-        ],
-        'COC (Cocina)' => [
-            'cocinero'            => ['label' => 'Cocinero',                 'descripcion' => 'Encargarse de la preparación de platos principales.'],
-        ],
-    ];
+    $grupos = cdb_get_criterios_empleado();
 
     // Encolar estilos y scripts si quieres
     $style_path = plugin_dir_path(dirname(__FILE__)) . 'style.css';


### PR DESCRIPTION
## Summary
- factor out employee criteria into `inc/criterios-empleado.php`
- include new helper in plugin bootstrap
- reuse helper in employee graph logic
- update admin page to load criteria labels from helper

## Testing
- `npm run build` *(fails: wp-scripts not found)*
- `npm ci` *(fails: 403 Forbidden / registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6886c6cccf1c83279d292318fa8acfe0