### PR TITLE
Fix radar chart labels

### DIFF
--- a/inc/grafica-empleado.php
+++ b/inc/grafica-empleado.php
@@ -86,8 +86,13 @@ function renderizar_bloque_grafica_empleado($attributes, $content) {
     }
 
     // Datos para la gráfica
+    // Extraemos solo las siglas (clave antes del espacio o paréntesis)
+    $siglas = array_map(function ($grupo) {
+        return strtok($grupo, ' ');
+    }, array_keys($grupos));
+
     $data = [
-        'labels'    => array_keys($grupos),
+        'labels'    => $siglas,
         'promedios' => $promedios,
         'total'     => $total,
     ];


### PR DESCRIPTION
## Summary
- show only group abbreviations in employee radar chart

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886cf855640832798b91dcef8401242