### PR TITLE
Centralize Bar graph criteria

### DIFF
--- a/admin/modificar_criterios.php
+++ b/admin/modificar_criterios.php
@@ -76,29 +76,35 @@ function cdb_grafica_modificar_criterios_page() {
             <?php
             // TODO: implementar edición de criterios existentes.
             // TODO: implementar creación de nuevos criterios.
-        } else {
-            $criterios = cdb_grafica_get_criterios_organizados( $tab );
             ?>
-            <form method="post" action="">
-                <table class="form-table">
+        <?php } else { ?>
+            <?php $criterios = cdb_get_criterios_bar(); ?>
+            <table class="widefat fixed striped">
+                <thead>
                     <tr>
-                        <th><label for="criterio_actual"><?php esc_html_e( 'Criterio a Reemplazar:', 'cdb-grafica' ); ?></label></th>
-                        <td>
-                            <select name="criterio_actual" id="criterio_actual">
-                                <?php foreach ( $criterios as $grupo => $items ) { ?>
-                                    <optgroup label="<?php echo esc_attr__( $grupo, 'cdb-grafica' ); ?>">
-                                        <?php foreach ( $items as $criterio ) { ?>
-                                            <option value="<?php echo esc_attr( $criterio ); ?>">
-                                                <?php echo esc_html__( $criterio, 'cdb-grafica' ); ?>
-                                            </option>
-                                        <?php } ?>
-                                    </optgroup>
-                                <?php } ?>
-                            </select>
-                        </td>
+                        <th><?php esc_html_e( 'Grupo', 'cdb-grafica' ); ?></th>
+                        <th><?php esc_html_e( 'Slug', 'cdb-grafica' ); ?></th>
+                        <th><?php esc_html_e( 'Etiqueta', 'cdb-grafica' ); ?></th>
+                        <th><?php esc_html_e( 'Descripción', 'cdb-grafica' ); ?></th>
                     </tr>
-                </table>
-            </form>
+                </thead>
+                <tbody>
+                    <?php foreach ( $criterios as $grupo => $items ) { ?>
+                        <?php foreach ( $items as $slug => $info ) { ?>
+                            <tr>
+                                <td><?php echo esc_html__( $grupo, 'cdb-grafica' ); ?></td>
+                                <td><?php echo esc_html( $slug ); ?></td>
+                                <td><?php echo esc_html( $info['label'] ); ?></td>
+                                <td><?php echo esc_html( $info['descripcion'] ); ?></td>
+                            </tr>
+                        <?php } ?>
+                    <?php } ?>
+                </tbody>
+            </table>
+            <?php
+            // TODO: implementar edición de criterios existentes.
+            // TODO: implementar creación de nuevos criterios.
+            ?>
         <?php } ?>
     </div>
     <?php
@@ -107,8 +113,15 @@ function cdb_grafica_modificar_criterios_page() {
 // Definir grupos de criterios reales
 function cdb_grafica_get_criterios_organizados($grafica_tipo) {
     if ($grafica_tipo === 'bar') {
-        $grupos = [
-                    ];
+        $criterios = cdb_get_criterios_bar();
+        $grupos    = [];
+        foreach ( $criterios as $grupo => $items ) {
+            $labels = [];
+            foreach ( $items as $info ) {
+                $labels[] = $info['label'];
+            }
+            $grupos[ $grupo ] = $labels;
+        }
     } elseif ($grafica_tipo === 'empleado') {
         $criterios = cdb_get_criterios_empleado();
         $grupos    = [];

--- a/cdb-grafica.php
+++ b/cdb-grafica.php
@@ -29,6 +29,7 @@ require_once plugin_dir_path(__FILE__) . 'admin/modificar_colores.php';
 
 
 // Requerir archivos de CPT y gráficas
+require_once __DIR__ . '/inc/criterios-bar.php';
 require_once __DIR__ . '/inc/grafica-bar.php';
 require_once __DIR__ . '/inc/criterios-empleado.php';
 require_once __DIR__ . '/inc/grafica-empleado.php';

--- a/inc/criterios-bar.php
+++ b/inc/criterios-bar.php
@@ -1,0 +1,57 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+function cdb_get_criterios_bar() {
+    return [
+        'DIB (Direccion)' => [
+            'relacion_superiores' => [
+                'label' => 'Relación con Superiores',
+                'descripcion' => 'Relación de los empleados con los supervisores o gerentes.'
+            ],
+        ],
+        'COE (Condiciones Económicas)' => [
+            'salario' => [
+                'label' => 'Salario',
+                'descripcion' => 'Adecuación del salario a las funciones desempeñadas.'
+            ],
+        ],
+        'EDT (Espacio de trabajo)' => [
+            'espacio_seguro' => [
+                'label' => 'Espacio Seguro',
+                'descripcion' => 'Percepción general de seguridad en el lugar de trabajo.'
+            ],
+        ],
+        'COL (Condiciones Laborales)' => [
+            'turnos_justos' => [
+                'label' => 'Turnos Justos',
+                'descripcion' => 'Distribución equitativa de turnos laborales entre los empleados.'
+            ],
+        ],
+        'EQU (Equipo)' => [
+            'motivacion' => [
+                'label' => 'Motivación',
+                'descripcion' => 'Capacidad del equipo para mantener la motivación alta.'
+            ],
+        ],
+        'ALB (Ambiente Laboral)' => [
+            'bienvenida' => [
+                'label' => 'Bienvenida',
+                'descripcion' => 'Valoración sobre cómo se recibe a los nuevos empleados en el equipo.'
+            ],
+        ],
+        'DPF (Desarrollo Profesional)' => [
+            'formacion' => [
+                'label' => 'Formación',
+                'descripcion' => 'Oportunidades de capacitación y formación profesional.'
+            ],
+        ],
+        'CLI (Clientela)' => [
+            'reputacion' => [
+                'label' => 'Reputación',
+                'descripcion' => 'Reputación general del lugar frente a los clientes.'
+            ],
+        ],
+    ];
+}

--- a/inc/grafica-bar.php
+++ b/inc/grafica-bar.php
@@ -59,36 +59,20 @@ $results = $wpdb->get_results($wpdb->prepare("
     SELECT * FROM $table_name WHERE post_id = %d
 ", $post_id));
 
-    // Inicializar grupos
-    $grupos = [
-        'DIB' => [
-            'relacion_superiores'
-        ],
-        'COE' => [
-            'salario'
-        ],
-        'EDT' => [
-            'espacio_seguro'
-        ],
-        'COL' => [
-            'turnos_justos'
-        ],
-        'EQU' => [
-            'motivacion'
-        ],
-        'ALB' => [
-            'bienvenida'
-        ],
-        'DPF' => [
-            'formacion'
-        ],
-        'CLI' => [
-            'reputacion'
-        ]
-    ];
+    // Inicializar grupos desde los criterios centralizados
+    $criterios = cdb_get_criterios_bar();
+    $grupos    = [];
+    foreach ( $criterios as $grupo_nombre => $campos ) {
+        $grupos[ $grupo_nombre ] = array_keys( $campos );
+    }
 
-    // Etiquetas de la gráfica
-    $etiquetas_grafica = array_keys($grupos);
+    // Usar solo las siglas como etiquetas de la gráfica
+    $etiquetas_grafica = array_map(
+        function ( $grupo ) {
+            return strtok( $grupo, ' ' );
+        },
+        array_keys( $grupos )
+    );
 
     // Calcular promedios
     $promedios = [];
@@ -303,56 +287,7 @@ add_shortcode('grafica_bar_form', function($atts) {
     ), ARRAY_A);
     
     // Definir los nombres y descripciones de las características
-    $grupos = [
-        'DIB (Direccion)' => [
-            'relacion_superiores' => [
-                'label' => 'Relación con Superiores', 
-                'descripcion' => 'Relación de los empleados con los supervisores o gerentes.'
-            ],
-        ],
-        'COE (Condiciones Económicas)' => [
-            'salario' => [
-                'label' => 'Salario', 
-                'descripcion' => 'Adecuación del salario a las funciones desempeñadas.'
-            ],
-        ],
-        'EDT (Espacio de trabajo)' => [
-            'espacio_seguro' => [
-                'label' => 'Espacio Seguro', 
-                'descripcion' => 'Percepción general de seguridad en el lugar de trabajo.'
-            ],
-        ],
-        'COL (Condiciones Laborales)' => [
-            'turnos_justos' => [
-                 'label' => 'Turnos Justos', 
-                'descripcion' => 'Distribución equitativa de turnos laborales entre los empleados.'
-            ],
-        ],
-        'EQU (Equipo)' => [
-            'motivacion' => [
-                'label' => 'Motivación', 
-                'descripcion' => 'Capacidad del equipo para mantener la motivación alta.'
-            ],
-        ],
-        'ALB (Ambiente Laboral)' => [
-            'bienvenida' => [
-                'label' => 'Bienvenida', 
-                'descripcion' => 'Valoración sobre cómo se recibe a los nuevos empleados en el equipo.'
-            ],
-        ],
-        'DPF (Desarrollo Profesional)' => [
-            'formacion' => [
-                'label' => 'Formación', 
-                'descripcion' => 'Oportunidades de capacitación y formación profesional.'
-            ],
-        ],
-        'CLI (Clientela)' => [
-            'reputacion' => [
-                'label' => 'Reputación', 
-                'descripcion' => 'Reputación general del lugar frente a los clientes.'
-            ],
-        ],
-    ];
+    $grupos = cdb_get_criterios_bar();
 
 // Encolar estilos y scripts (acordeón, etc.)
     $style_path = plugin_dir_path(dirname(__FILE__)) . 'style.css';


### PR DESCRIPTION
## Summary
- centralize bar criteria in new helper `cdb_get_criterios_bar`
- load helper in main plugin file
- update bar graph logic to use centralized criteria
- display bar criteria in admin panel using helper

## Testing
- `php -l inc/criterios-bar.php`
- `php -l inc/grafica-bar.php`
- `php -l admin/modificar_criterios.php`
- `php -l cdb-grafica.php`
- `npm run build` *(fails: wp-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886d14250888327a257e0231988a883