### PR TITLE
Implement criterion creation from admin

### DIFF
--- a/languages/cdb-grafica.pot
+++ b/languages/cdb-grafica.pot
@@ -148,3 +148,27 @@ msgstr ""
 #: cdb-grafica.php:74
 msgid "No se encontraron datos."
 msgstr ""
+
+#: admin/modificar_criterios.php
+msgid "Criterio actualizado."
+msgstr ""
+
+#: admin/modificar_criterios.php
+msgid "Criterio añadido."
+msgstr ""
+
+#: admin/modificar_criterios.php
+msgid "El slug ya existe en este grupo."
+msgstr ""
+
+#: admin/modificar_criterios.php
+msgid "Grupo inválido."
+msgstr ""
+
+#: admin/modificar_criterios.php
+msgid "Por favor completa los campos obligatorios."
+msgstr ""
+
+#: admin/modificar_criterios.php
+msgid "Añadir Criterio"
+msgstr ""


### PR DESCRIPTION
## Summary
- add ability to create new evaluation criteria in admin
- list "Add Criterion" action for both employee and bar tables
- save new criteria to helper files with backup
- update translation template

## Testing
- `php -l admin/modificar_criterios.php`

------
https://chatgpt.com/codex/tasks/task_e_6886dc64ac7c8327817200f6598b74ac