### PR TITLE
Add visibility flag to criteria

### DIFF
--- a/admin/modificar_criterios.php
+++ b/admin/modificar_criterios.php
@@ -377,9 +377,13 @@ function cdb_grafica_get_criterios_organizados($grafica_tipo) {
         foreach ( $criterios as $grupo => $items ) {
             $labels = [];
             foreach ( $items as $info ) {
-                $labels[] = $info['label'];
+                if ( $info['visible'] ?? true ) {
+                    $labels[] = $info['label'];
+                }
             }
-            $grupos[ $grupo ] = $labels;
+            if ( ! empty( $labels ) ) {
+                $grupos[ $grupo ] = $labels;
+            }
         }
     } elseif ($grafica_tipo === 'empleado') {
         $criterios = cdb_get_criterios_empleado();
@@ -387,9 +391,13 @@ function cdb_grafica_get_criterios_organizados($grafica_tipo) {
         foreach ($criterios as $grupo => $items) {
             $labels = [];
             foreach ($items as $info) {
-                $labels[] = $info['label'];
+                if ( $info['visible'] ?? true ) {
+                    $labels[] = $info['label'];
+                }
             }
-            $grupos[$grupo] = $labels;
+            if ( ! empty( $labels ) ) {
+                $grupos[$grupo] = $labels;
+            }
         }
     } else {
         $grupos = [];

--- a/inc/criterios-bar.php
+++ b/inc/criterios-bar.php
@@ -8,49 +8,57 @@ function cdb_get_criterios_bar() {
         'DIB (Direccion)' => [
             'relacion_superiores' => [
                 'label' => 'Relación con Superiores',
-                'descripcion' => 'Relación de los empleados con los supervisores o gerentes.'
+                'descripcion' => 'Relación de los empleados con los supervisores o gerentes.',
+                'visible' => true,
             ],
         ],
         'COE (Condiciones Económicas)' => [
             'salario' => [
                 'label' => 'Salario',
-                'descripcion' => 'Adecuación del salario a las funciones desempeñadas.'
+                'descripcion' => 'Adecuación del salario a las funciones desempeñadas.',
+                'visible' => true,
             ],
         ],
         'EDT (Espacio de trabajo)' => [
             'espacio_seguro' => [
                 'label' => 'Espacio Seguro',
-                'descripcion' => 'Percepción general de seguridad en el lugar de trabajo.'
+                'descripcion' => 'Percepción general de seguridad en el lugar de trabajo.',
+                'visible' => true,
             ],
         ],
         'COL (Condiciones Laborales)' => [
             'turnos_justos' => [
                 'label' => 'Turnos Justos',
-                'descripcion' => 'Distribución equitativa de turnos laborales entre los empleados.'
+                'descripcion' => 'Distribución equitativa de turnos laborales entre los empleados.',
+                'visible' => true,
             ],
         ],
         'EQU (Equipo)' => [
             'motivacion' => [
                 'label' => 'Motivación',
-                'descripcion' => 'Capacidad del equipo para mantener la motivación alta.'
+                'descripcion' => 'Capacidad del equipo para mantener la motivación alta.',
+                'visible' => true,
             ],
         ],
         'ALB (Ambiente Laboral)' => [
             'bienvenida' => [
                 'label' => 'Bienvenida',
-                'descripcion' => 'Valoración sobre cómo se recibe a los nuevos empleados en el equipo.'
+                'descripcion' => 'Valoración sobre cómo se recibe a los nuevos empleados en el equipo.',
+                'visible' => true,
             ],
         ],
         'DPF (Desarrollo Profesional)' => [
             'formacion' => [
                 'label' => 'Formación',
-                'descripcion' => 'Oportunidades de capacitación y formación profesional.'
+                'descripcion' => 'Oportunidades de capacitación y formación profesional.',
+                'visible' => true,
             ],
         ],
         'CLI (Clientela)' => [
             'reputacion' => [
                 'label' => 'Reputación',
-                'descripcion' => 'Reputación general del lugar frente a los clientes.'
+                'descripcion' => 'Reputación general del lugar frente a los clientes.',
+                'visible' => true,
             ],
         ],
     ];

--- a/inc/criterios-empleado.php
+++ b/inc/criterios-empleado.php
@@ -8,49 +8,57 @@ function cdb_get_criterios_empleado() {
         'DIE (Dirección)' => [
             'direccion' => [
                 'label' => 'Dirección',
-                'descripcion' => 'Guiar al equipo hacia los objetivos comunes.'
+                'descripcion' => 'Guiar al equipo hacia los objetivos comunes.',
+                'visible' => true,
             ],
         ],
         'SAL (Sala)' => [
             'camarero' => [
                 'label' => 'Camarero',
-                'descripcion' => 'Atender y servir a los clientes en sala.'
+                'descripcion' => 'Atender y servir a los clientes en sala.',
+                'visible' => true,
             ],
         ],
         'TES (Técnica Sala)' => [
             'venta' => [
                 'label' => 'Venta',
-                'descripcion' => 'Capacidades comerciales de venta.'
+                'descripcion' => 'Capacidades comerciales de venta.',
+                'visible' => true,
             ],
         ],
         'ATC (Atención al Cliente)' => [
             'satisfaccion' => [
                 'label' => 'Satisfacción',
-                'descripcion' => 'Garantizar una experiencia positiva para el cliente.'
+                'descripcion' => 'Garantizar una experiencia positiva para el cliente.',
+                'visible' => true,
             ],
         ],
         'TEQ (Trabajo en Equipo)' => [
             'cooperacion' => [
                 'label' => 'Cooperación',
-                'descripcion' => 'Colaborar para lograr objetivos comunes.'
+                'descripcion' => 'Colaborar para lograr objetivos comunes.',
+                'visible' => true,
             ],
         ],
         'ORL (Orden y Limpieza)' => [
             'orden' => [
                 'label' => 'Orden',
-                'descripcion' => 'Organizar el espacio y tareas de forma eficiente.'
+                'descripcion' => 'Organizar el espacio y tareas de forma eficiente.',
+                'visible' => true,
             ],
         ],
         'TEC (Técnica de Cocina)' => [
             'cocina_local' => [
                 'label' => 'Cocina Local',
-                'descripcion' => 'Dominar técnicas culinarias locales.'
+                'descripcion' => 'Dominar técnicas culinarias locales.',
+                'visible' => true,
             ],
         ],
         'COC (Cocina)' => [
             'cocinero' => [
                 'label' => 'Cocinero',
-                'descripcion' => 'Encargarse de la preparación de platos principales.'
+                'descripcion' => 'Encargarse de la preparación de platos principales.',
+                'visible' => true,
             ],
         ],
     ];

--- a/inc/grafica-bar.php
+++ b/inc/grafica-bar.php
@@ -63,7 +63,15 @@ $results = $wpdb->get_results($wpdb->prepare("
     $criterios = cdb_get_criterios_bar();
     $grupos    = [];
     foreach ( $criterios as $grupo_nombre => $campos ) {
-        $grupos[ $grupo_nombre ] = array_keys( $campos );
+        $campos_visibles = array_filter(
+            $campos,
+            function ( $info ) {
+                return $info['visible'] ?? true;
+            }
+        );
+        if ( ! empty( $campos_visibles ) ) {
+            $grupos[ $grupo_nombre ] = array_keys( $campos_visibles );
+        }
     }
 
     // Usar solo las siglas como etiquetas de la gráfica
@@ -320,7 +328,17 @@ add_shortcode('grafica_bar_form', function($atts) {
         <input type="hidden" name="post_id" value="<?php echo esc_attr($post_id); ?>">
         <?php wp_nonce_field('submit_grafica_bar', 'grafica_bar_nonce'); ?>
 
-        <?php foreach ($grupos as $grupo_nombre => $campos): ?>
+        <?php foreach ($grupos as $grupo_nombre => $campos):
+            $campos_visibles = array_filter(
+                $campos,
+                function ( $info ) {
+                    return $info['visible'] ?? true;
+                }
+            );
+            if ( empty( $campos_visibles ) ) {
+                continue;
+            }
+        ?>
             <div class="accordion">
                 <div class="accordion-header">
                     <button type="button" class="accordion-toggle">
@@ -328,7 +346,7 @@ add_shortcode('grafica_bar_form', function($atts) {
                     </button>
                 </div>
                 <div class="accordion-content" style="display: none;">
-                    <?php foreach ($campos as $campo_slug => $campo_info): 
+                    <?php foreach ($campos_visibles as $campo_slug => $campo_info):
                         $valor_existente = isset($existing_data[$campo_slug]) ? $existing_data[$campo_slug] : '';
                     ?>
                     <label for="<?php echo esc_attr($campo_slug); ?>">

--- a/inc/grafica-empleado.php
+++ b/inc/grafica-empleado.php
@@ -57,7 +57,15 @@ function renderizar_bloque_grafica_empleado($attributes, $content) {
     $criterios = cdb_get_criterios_empleado();
     $grupos    = [];
     foreach ($criterios as $grupo_nombre => $campos) {
-        $grupos[$grupo_nombre] = array_keys($campos);
+        $campos_visibles = array_filter(
+            $campos,
+            function ( $info ) {
+                return $info['visible'] ?? true;
+            }
+        );
+        if ( ! empty( $campos_visibles ) ) {
+            $grupos[$grupo_nombre] = array_keys($campos_visibles);
+        }
     }
 
     // Calcular promedios por grupo
@@ -348,7 +356,17 @@ if (in_array('empleador', $roles) && $puede_calificar) {
         <input type="hidden" name="post_id" value="<?php echo esc_attr($post_id); ?>">
         <?php wp_nonce_field('submit_grafica_empleado', 'grafica_empleado_nonce'); ?>
 
-        <?php foreach ($grupos as $grupo_nombre => $campos): ?>
+        <?php foreach ($grupos as $grupo_nombre => $campos):
+            $campos_visibles = array_filter(
+                $campos,
+                function ( $info ) {
+                    return $info['visible'] ?? true;
+                }
+            );
+            if ( empty( $campos_visibles ) ) {
+                continue;
+            }
+        ?>
             <div class="accordion">
                 <div class="accordion-header">
                     <button type="button" class="accordion-toggle">
@@ -356,7 +374,7 @@ if (in_array('empleador', $roles) && $puede_calificar) {
                     </button>
                 </div>
                 <div class="accordion-content" style="display: none;">
-                    <?php foreach ($campos as $campo_slug => $campo_info): 
+                    <?php foreach ($campos_visibles as $campo_slug => $campo_info):
                         $valor_existente = isset($existing_data[$campo_slug]) ? $existing_data[$campo_slug] : '';
                     ?>
                         <label for="<?php echo esc_attr($campo_slug); ?>">


### PR DESCRIPTION
## Summary
- support hiding criteria via `visible` flag
- skip invisible fields when rendering forms or charts
- respect visibility in admin grouping

## Testing
- `php -l inc/criterios-bar.php`
- `php -l inc/criterios-empleado.php`
- `php -l inc/grafica-bar.php`
- `php -l inc/grafica-empleado.php`
- `php -l admin/modificar_criterios.php`
- `npm ci` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688750e0d6988327a4060083c1576497