### PR TITLE
Add user_role column to results

### DIFF
--- a/cdb-grafica.php
+++ b/cdb-grafica.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: CDB Gráfica
  * Description: Plugin para manejar gráficas (bar y empleado) y sus tablas.
- * Version: 1.0.0
+ * Version: 1.1.0
  * Author: CdB_
  * Author URI: https://proyectocdb.es
  * Text Domain: cdb-grafica
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Versión actual del plugin
-define('CDB_GRAFICA_VERSION', '1.0.0');
+define('CDB_GRAFICA_VERSION', '1.1.0');
 
 // Cargar traducciones
 function cdb_grafica_load_textdomain() {

--- a/inc/grafica-bar.php
+++ b/inc/grafica-bar.php
@@ -199,6 +199,7 @@ function grafica_bar_create_table() {
         id BIGINT(20) NOT NULL AUTO_INCREMENT,
         post_id BIGINT(20) NOT NULL,
         user_id BIGINT(20) NOT NULL,
+        user_role VARCHAR(50) NOT NULL,
         relacion_superiores FLOAT NOT NULL,
         salario FLOAT NOT NULL,
         espacio_seguro FLOAT NOT NULL,
@@ -439,10 +440,18 @@ if (in_array('empleado', $roles)) {
         // Otros roles sin restricción
 
         // Preparar datos para insertar o actualizar
-        $data   = ['post_id' => $post_id, 'user_id' => $user_id];
+        $data   = [
+            'post_id' => $post_id,
+            'user_id' => $user_id,
+        ];
         $fields = $wpdb->get_col("SHOW COLUMNS FROM $table_name");
+
+        if (in_array('user_role', $fields, true) && !empty($user->roles)) {
+            $data['user_role'] = sanitize_text_field($user->roles[0]);
+        }
+
         foreach ($fields as $field) {
-            if ($field === 'id' || $field === 'created_at') {
+            if ($field === 'id' || $field === 'created_at' || $field === 'user_role') {
                 continue; // Ignore auto fields
             }
             if (isset($_POST[$field])) {

--- a/inc/grafica-empleado.php
+++ b/inc/grafica-empleado.php
@@ -192,6 +192,7 @@ function grafica_empleado_create_table() {
         id BIGINT(20) NOT NULL AUTO_INCREMENT,
         post_id BIGINT(20) NOT NULL,
         user_id BIGINT(20) NOT NULL,
+        user_role VARCHAR(50) NOT NULL,
         direccion FLOAT NOT NULL,
         camarero FLOAT NOT NULL,
         venta FLOAT NOT NULL,
@@ -496,10 +497,19 @@ if (in_array('empleador', $roles)) {
         // Otros roles sin restricciones
 
         // Preparar datos
-        $data   = ['post_id' => $post_id, 'user_id' => $user_id];
-        $fields = $wpdb->get_col("SHOW COLUMNS FROM $table_name");
+        $data   = [
+            'post_id' => $post_id,
+            'user_id' => $user_id,
+        ];
+        $fields     = $wpdb->get_col("SHOW COLUMNS FROM $table_name");
+
+        // Añadir el rol si la columna existe
+        if (in_array('user_role', $fields, true) && !empty($user->roles)) {
+            $data['user_role'] = sanitize_text_field($user->roles[0]);
+        }
+
         foreach ($fields as $field) {
-            if (isset($_POST[$field]) && $field !== 'id' && $field !== 'created_at') {
+            if (isset($_POST[$field]) && $field !== 'id' && $field !== 'created_at' && $field !== 'user_role') {
                 $data[$field] = floatval($_POST[$field]);
             }
         }


### PR DESCRIPTION
## Summary
- add `user_role` column to bar and empleado tables
- record user's primary role when inserting or updating results
- bump plugin version to 1.1.0

## Testing
- `php -l inc/grafica-empleado.php`
- `php -l inc/grafica-bar.php`
- `php -l cdb-grafica.php`


------
https://chatgpt.com/codex/tasks/task_e_6887d00378f08327abe6447173a9246a