### PR TITLE
Add employer and tutor color settings

### DIFF
--- a/admin/modificar_colores.php
+++ b/admin/modificar_colores.php
@@ -18,12 +18,16 @@ add_action('admin_menu', 'cdb_grafica_colores_menu');
 function cdb_grafica_colores_page() {
     if (isset($_POST['cdb_grafica_colores_nonce']) && wp_verify_nonce($_POST['cdb_grafica_colores_nonce'], 'cdb_guardar_colores')) {
         $colores = [
-            'bar_background'      => sanitize_text_field($_POST['bar_background'] ?? ''),
-            'bar_border'          => sanitize_text_field($_POST['bar_border'] ?? ''),
-            'empleado_background' => sanitize_text_field($_POST['empleado_background'] ?? ''),
-            'empleado_border'     => sanitize_text_field($_POST['empleado_border'] ?? ''),
-            'ticks_color'         => sanitize_text_field($_POST['ticks_color'] ?? ''),
-            'ticks_backdrop'      => sanitize_text_field($_POST['ticks_backdrop'] ?? ''),
+            'bar_background'       => sanitize_text_field($_POST['bar_background'] ?? ''),
+            'bar_border'           => sanitize_text_field($_POST['bar_border'] ?? ''),
+            'empleado_background'  => sanitize_text_field($_POST['empleado_background'] ?? ''),
+            'empleado_border'      => sanitize_text_field($_POST['empleado_border'] ?? ''),
+            'empleador_background' => sanitize_text_field($_POST['empleador_background'] ?? ''),
+            'empleador_border'     => sanitize_text_field($_POST['empleador_border'] ?? ''),
+            'tutor_background'     => sanitize_text_field($_POST['tutor_background'] ?? ''),
+            'tutor_border'         => sanitize_text_field($_POST['tutor_border'] ?? ''),
+            'ticks_color'          => sanitize_text_field($_POST['ticks_color'] ?? ''),
+            'ticks_backdrop'       => sanitize_text_field($_POST['ticks_backdrop'] ?? ''),
         ];
         update_option('cdb_grafica_colores', $colores);
         echo '<div class="updated"><p>'; 
@@ -32,12 +36,16 @@ function cdb_grafica_colores_page() {
     }
 
     $defaults = [
-        'bar_background'      => 'rgba(75, 192, 192, 0.2)',
-        'bar_border'          => 'rgba(75, 192, 192, 1)',
-        'empleado_background' => 'rgba(75, 192, 192, 0.2)',
-        'empleado_border'     => 'rgba(75, 192, 192, 1)',
-        'ticks_color'         => '#666666',
-        'ticks_backdrop'      => '',
+        'bar_background'       => 'rgba(75, 192, 192, 0.2)',
+        'bar_border'           => 'rgba(75, 192, 192, 1)',
+        'empleado_background'  => 'rgba(75, 192, 192, 0.2)',
+        'empleado_border'      => 'rgba(75, 192, 192, 1)',
+        'empleador_background' => 'rgba(54, 162, 235, 0.2)',
+        'empleador_border'     => 'rgba(54, 162, 235, 1)',
+        'tutor_background'     => 'rgba(255, 99, 132, 0.2)',
+        'tutor_border'         => 'rgba(255, 99, 132, 1)',
+        'ticks_color'          => '#666666',
+        'ticks_backdrop'       => '',
     ];
     $colores = get_option('cdb_grafica_colores', $defaults);
 
@@ -81,6 +89,22 @@ function cdb_grafica_colores_page() {
                 <tr>
                     <th scope="row"><?php esc_html_e( 'Empleado - Color de borde', 'cdb-grafica' ); ?></th>
                     <td><input type="text" name="empleado_border" value="<?php echo esc_attr($colores['empleado_border']); ?>" class="cdb-color-field" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><?php esc_html_e( 'Empleador - Color de fondo', 'cdb-grafica' ); ?></th>
+                    <td><input type="text" name="empleador_background" value="<?php echo esc_attr($colores['empleador_background']); ?>" class="cdb-color-field" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><?php esc_html_e( 'Empleador - Color de borde', 'cdb-grafica' ); ?></th>
+                    <td><input type="text" name="empleador_border" value="<?php echo esc_attr($colores['empleador_border']); ?>" class="cdb-color-field" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><?php esc_html_e( 'Tutor - Color de fondo', 'cdb-grafica' ); ?></th>
+                    <td><input type="text" name="tutor_background" value="<?php echo esc_attr($colores['tutor_background']); ?>" class="cdb-color-field" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><?php esc_html_e( 'Tutor - Color de borde', 'cdb-grafica' ); ?></th>
+                    <td><input type="text" name="tutor_border" value="<?php echo esc_attr($colores['tutor_border']); ?>" class="cdb-color-field" /></td>
                 </tr>
                 <tr>
                     <th scope="row"><?php esc_html_e( 'Ticks - Color', 'cdb-grafica' ); ?></th>

--- a/inc/grafica-empleado.php
+++ b/inc/grafica-empleado.php
@@ -135,21 +135,42 @@ function renderizar_bloque_grafica_empleado($attributes, $content) {
 
     // Obtener colores configurados
     $defaults = [
-        'empleado_background' => 'rgba(75, 192, 192, 0.2)',
-        'empleado_border'     => 'rgba(75, 192, 192, 1)',
-        'ticks_color'         => '#666666',
-        'ticks_backdrop'      => ''
+        'empleado_background'  => 'rgba(75, 192, 192, 0.2)',
+        'empleado_border'      => 'rgba(75, 192, 192, 1)',
+        'empleador_background' => 'rgba(54, 162, 235, 0.2)',
+        'empleador_border'     => 'rgba(54, 162, 235, 1)',
+        'tutor_background'     => 'rgba(255, 99, 132, 0.2)',
+        'tutor_border'         => 'rgba(255, 99, 132, 1)',
+        'ticks_color'          => '#666666',
+        'ticks_backdrop'       => ''
     ];
-    $opts     = get_option('cdb_grafica_colores', $defaults);
-    $attributes['backgroundColor']   = $opts['empleado_background'] ?? $defaults['empleado_background'];
-    $attributes['borderColor']       = $opts['empleado_border'] ?? $defaults['empleado_border'];
-    $attributes['ticksColor']        = $opts['ticks_color'] ?? $defaults['ticks_color'];
+    $opts        = get_option('cdb_grafica_colores', $defaults);
+
+    $role_colors = [
+        'empleado'  => [
+            'background' => $opts['empleado_background'] ?? $defaults['empleado_background'],
+            'border'     => $opts['empleado_border'] ?? $defaults['empleado_border'],
+        ],
+        'empleador' => [
+            'background' => $opts['empleador_background'] ?? $defaults['empleador_background'],
+            'border'     => $opts['empleador_border'] ?? $defaults['empleador_border'],
+        ],
+        'tutor'     => [
+            'background' => $opts['tutor_background'] ?? $defaults['tutor_background'],
+            'border'     => $opts['tutor_border'] ?? $defaults['tutor_border'],
+        ],
+    ];
+
+    $attributes['backgroundColor']    = $role_colors['empleado']['background'];
+    $attributes['borderColor']        = $role_colors['empleado']['border'];
+    $attributes['ticksColor']         = $opts['ticks_color'] ?? $defaults['ticks_color'];
     $attributes['ticksBackdropColor'] = $opts['ticks_backdrop'] ?? $defaults['ticks_backdrop'];
 
     ob_start();
     ?>
     <div id="grafica-empleado"
          data-valores="<?php echo esc_attr(wp_json_encode($data)); ?>"
+         data-role-colors="<?php echo esc_attr(wp_json_encode($role_colors)); ?>"
          data-background-color="<?php echo esc_attr($attributes['backgroundColor']); ?>"
          data-border-color="<?php echo esc_attr($attributes['borderColor']); ?>"
          data-ticks-color="<?php echo esc_attr($attributes['ticksColor']); ?>"
@@ -172,11 +193,7 @@ function generar_grafica_empleado_en_frontend() {
             const ctx = document.createElement('canvas');
             dataElement.appendChild(ctx);
 
-            const colores = {
-                empleado: 'blue',
-                empleador: 'green',
-                tutor: 'red'
-            };
+            const colores = JSON.parse(dataElement.dataset.roleColors || '{}');
 
             const chartData = {
                 labels: data.labels,
@@ -186,11 +203,12 @@ function generar_grafica_empleado_en_frontend() {
             if (data.datasets) {
                 Object.keys(data.datasets).forEach(function (rol) {
                     const valores = data.datasets[rol];
+                    const cfg = colores[rol] || {};
                     chartData.datasets.push({
                         label: rol,
                         data: valores,
-                        backgroundColor: colores[rol] || 'gray',
-                        borderColor: colores[rol] || 'gray',
+                        backgroundColor: cfg.background || 'gray',
+                        borderColor: cfg.border || 'gray',
                         borderWidth: 2
                     });
                 });


### PR DESCRIPTION
## Summary
- add color fields for employer and tutor roles
- store per-role color options and expose them to the frontend
- update radar chart to apply saved colors per role

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: wp-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887e2c1a0b483278c9f769fb9fc83e8