### PR TITLE
Improve labels for employee chart colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ Si se deja un criterio sin valorar, la puntuación guardada es 0 y no se tendrá
 Dentro del menú **CdB Gráfica** se encuentra el submenú **Configurar Colores**. Desde esta página puedes modificar los colores utilizados en las gráficas:
 
 - **Bar – Color de fondo** y **Bar – Color de borde** definen el aspecto del dataset de bares.
-- **Empleado – Color de fondo** y **Empleado – Color de borde** controlan el dataset de empleados.
+- En la sección **Gráfica Empleado** puedes ajustar:
+  - **Valores aportados por los Empleados – Color de fondo**
+  - **Valores aportados por los Empleados – Color de borde**
+  - **Valores aportados por los Empleadores – Color de fondo**
+  - **Valores aportados por los Empleadores – Color de borde**
+  - **Valores aportados por los Tutores – Color de fondo**
+  - **Valores aportados por los Tutores – Color de borde**
 
 Cada selector cuenta con un deslizador *Alpha* que permite ajustar la transparencia del color. Los valores se guardan en formato `rgba`, por lo que puedes elegir tonalidades semitransparentes que se aplicarán directamente en las gráficas.
 

--- a/admin/modificar_colores.php
+++ b/admin/modificar_colores.php
@@ -68,6 +68,11 @@ function cdb_grafica_colores_page() {
         filemtime($alpha_js_path),
         true
     );
+    wp_localize_script(
+        'cdb-rgba-color-picker',
+        'cdbGraficaI18n',
+        [ 'alphaLabel' => __( 'Transparencia del color de fondo', 'cdb-grafica' ) ]
+    );
     ?>
     <div class="wrap">
         <h1><?php esc_html_e( 'Configurar Colores', 'cdb-grafica' ); ?></h1>
@@ -82,28 +87,31 @@ function cdb_grafica_colores_page() {
                     <th scope="row"><?php esc_html_e( 'Bar - Color de borde', 'cdb-grafica' ); ?></th>
                     <td><input type="text" name="bar_border" value="<?php echo esc_attr($colores['bar_border']); ?>" class="cdb-color-field" /></td>
                 </tr>
+                <tr class="cdb-section">
+                    <th colspan="2"><h2><?php esc_html_e( 'Gráfica Empleado', 'cdb-grafica' ); ?></h2></th>
+                </tr>
                 <tr>
-                    <th scope="row"><?php esc_html_e( 'Empleado - Color de fondo', 'cdb-grafica' ); ?></th>
+                    <th scope="row"><?php esc_html_e( 'Valores aportados por los Empleados – Color de fondo', 'cdb-grafica' ); ?></th>
                     <td><input type="text" name="empleado_background" value="<?php echo esc_attr($colores['empleado_background']); ?>" class="cdb-color-field" /></td>
                 </tr>
                 <tr>
-                    <th scope="row"><?php esc_html_e( 'Empleado - Color de borde', 'cdb-grafica' ); ?></th>
+                    <th scope="row"><?php esc_html_e( 'Valores aportados por los Empleados – Color de borde', 'cdb-grafica' ); ?></th>
                     <td><input type="text" name="empleado_border" value="<?php echo esc_attr($colores['empleado_border']); ?>" class="cdb-color-field" /></td>
                 </tr>
                 <tr>
-                    <th scope="row"><?php esc_html_e( 'Empleador - Color de fondo', 'cdb-grafica' ); ?></th>
+                    <th scope="row"><?php esc_html_e( 'Valores aportados por los Empleadores – Color de fondo', 'cdb-grafica' ); ?></th>
                     <td><input type="text" name="empleador_background" value="<?php echo esc_attr($colores['empleador_background']); ?>" class="cdb-color-field" /></td>
                 </tr>
                 <tr>
-                    <th scope="row"><?php esc_html_e( 'Empleador - Color de borde', 'cdb-grafica' ); ?></th>
+                    <th scope="row"><?php esc_html_e( 'Valores aportados por los Empleadores – Color de borde', 'cdb-grafica' ); ?></th>
                     <td><input type="text" name="empleador_border" value="<?php echo esc_attr($colores['empleador_border']); ?>" class="cdb-color-field" /></td>
                 </tr>
                 <tr>
-                    <th scope="row"><?php esc_html_e( 'Tutor - Color de fondo', 'cdb-grafica' ); ?></th>
+                    <th scope="row"><?php esc_html_e( 'Valores aportados por los Tutores – Color de fondo', 'cdb-grafica' ); ?></th>
                     <td><input type="text" name="tutor_background" value="<?php echo esc_attr($colores['tutor_background']); ?>" class="cdb-color-field" /></td>
                 </tr>
                 <tr>
-                    <th scope="row"><?php esc_html_e( 'Tutor - Color de borde', 'cdb-grafica' ); ?></th>
+                    <th scope="row"><?php esc_html_e( 'Valores aportados por los Tutores – Color de borde', 'cdb-grafica' ); ?></th>
                     <td><input type="text" name="tutor_border" value="<?php echo esc_attr($colores['tutor_border']); ?>" class="cdb-color-field" /></td>
                 </tr>
                 <tr>

--- a/admin/rgba-color-picker.css
+++ b/admin/rgba-color-picker.css
@@ -4,3 +4,8 @@
 .rgba-alpha input {
     width: 100%;
 }
+.rgba-alpha label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}

--- a/admin/rgba-color-picker.js
+++ b/admin/rgba-color-picker.js
@@ -30,7 +30,8 @@
 
             var $container = $input.closest('.wp-picker-container');
             var $holder = $container.find('.wp-picker-holder');
-            var $alphaWrap = $('<div class="rgba-alpha"><input type="range" min="0" max="1" step="0.01" value="'+rgba.a+'" /></div>');
+            var label = window.cdbGraficaI18n ? window.cdbGraficaI18n.alphaLabel : 'Alpha';
+            var $alphaWrap = $('<div class="rgba-alpha"><label>'+label+' <input type="range" min="0" max="1" step="0.01" value="'+rgba.a+'" /></label></div>');
             $alphaWrap.insertAfter($holder);
 
             $alphaWrap.on('input', 'input', function(){

--- a/languages/cdb-grafica.pot
+++ b/languages/cdb-grafica.pot
@@ -125,12 +125,31 @@ msgstr ""
 msgid "Bar - Color de borde"
 msgstr ""
 
+#: admin/modificar_colores.php:88
+msgid "Gráfica Empleado"
+msgstr ""
+
 #: admin/modificar_colores.php:75
-msgid "Empleado - Color de fondo"
+msgid "Valores aportados por los Empleados – Color de fondo"
 msgstr ""
 
 #: admin/modificar_colores.php:79
-msgid "Empleado - Color de borde"
+msgid "Valores aportados por los Empleados – Color de borde"
+msgstr ""
+#: admin/modificar_colores.php:100
+msgid "Valores aportados por los Empleadores – Color de fondo"
+msgstr ""
+#: admin/modificar_colores.php:104
+msgid "Valores aportados por los Empleadores – Color de borde"
+msgstr ""
+#: admin/modificar_colores.php:108
+msgid "Valores aportados por los Tutores – Color de fondo"
+msgstr ""
+#: admin/modificar_colores.php:112
+msgid "Valores aportados por los Tutores – Color de borde"
+msgstr ""
+#: admin/modificar_colores.php:67
+msgid "Transparencia del color de fondo"
 msgstr ""
 
 #: admin/modificar_colores.php:83


### PR DESCRIPTION
## Summary
- make labels for the employee chart color settings clearer
- group employee chart settings under a new heading
- show a label for the alpha slider
- document the new labels in README
- update translation template

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6887ed1c880483279086ec5b96550654