### PR TITLE
Send email also on review updates

### DIFF
--- a/inc/grafica-bar.php
+++ b/inc/grafica-bar.php
@@ -467,11 +467,16 @@ if (in_array('empleado', $roles)) {
 
         if ($existing_row) {
             $wpdb->update($table_name, $data, ['id' => $existing_row]);
+            $row_id = $existing_row;
+            $accion = 'actualizacion';
         } else {
             $wpdb->insert($table_name, $data);
-            if ( ! empty( $wpdb->insert_id ) ) {
-                cdb_mails_send_new_review_notification( $wpdb->insert_id, 'bar' );
-            }
+            $row_id = $wpdb->insert_id;
+            $accion = 'nueva';
+        }
+
+        if ( ! empty( $row_id ) ) {
+            cdb_mails_send_new_review_notification( $row_id, 'bar', $accion );
         }
 
         wp_safe_redirect( get_permalink( $post_id ) );

--- a/inc/grafica-empleado.php
+++ b/inc/grafica-empleado.php
@@ -611,11 +611,16 @@ if (in_array('empleador', $roles)) {
 
         if ($existing_row) {
             $wpdb->update($table_name, $data, ['id' => $existing_row]);
+            $row_id = $existing_row;
+            $accion = 'actualizacion';
         } else {
             $wpdb->insert($table_name, $data);
-            if ( ! empty( $wpdb->insert_id ) ) {
-                cdb_mails_send_new_review_notification( $wpdb->insert_id, 'empleado' );
-            }
+            $row_id = $wpdb->insert_id;
+            $accion = 'nueva';
+        }
+
+        if ( ! empty( $row_id ) ) {
+            cdb_mails_send_new_review_notification( $row_id, 'empleado', $accion );
         }
 
         // Redirigir


### PR DESCRIPTION
## Summary
- notify via `cdb_mails_send_new_review_notification` after inserting **or updating** reviews
- provide action info (`nueva` vs `actualizacion`) to the mailer for bar and empleado reviews

## Testing
- `php -l inc/grafica-bar.php`
- `php -l inc/grafica-empleado.php`
- `npm run build` *(fails: `wp-scripts: not found`)*
- `npm ci` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688a5f8e98f083279c1a651f9b63b6da