### PR TITLE
Expose public helpers for employee graph scores

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,48 @@ Al guardar los cambios, los nuevos valores se aplican automáticamente a las gr�
 ## Desinstalación
 
 Al desinstalar el plugin se eliminan las tablas creadas para almacenar los resultados.
+
+## API Pública
+
+El plugin expone dos helpers para que otros plugins (p.ej. `cdb-form`) puedan obtener
+información de las valoraciones de empleados sin replicar la lógica de las gráficas.
+
+### Obtener fecha de última valoración
+
+```php
+string|null cdb_grafica_get_last_rating_datetime( int $empleado_id )
+```
+
+Devuelve la fecha/hora (`Y-m-d H:i:s`) de la última valoración registrada para el
+empleado o `null` si no existen datos.
+
+### Obtener puntuaciones por rol
+
+```php
+array cdb_grafica_get_scores_by_role( int $empleado_id, array $args = [] )
+```
+
+Retorna los totales de cada rol (`empleado`, `empleador`, `tutor`) con un decimal.
+Si se pasa `['with_detail' => true]` incluye el desglose por grupos.
+
+```php
+[
+  'empleado'  => 33.1,
+  'empleador' => 28.7,
+  'tutor'     => null,
+  'detalle'   => [
+     'empleado' => ['grupos' => ['DIE' => 7.5, 'SAL' => 6.2], 'total' => 33.1],
+     'empleador'=> [...]
+  ]
+]
+```
+
+### Transients y filtros
+
+- `cdb_grafica_last_rating_{ID}` guarda la fecha de última valoración.
+- `cdb_grafica_role_scores_{ID}` almacena los totales por rol.
+- Filtros disponibles: `cdb_grafica_last_rating_args`,
+  `cdb_grafica_scores_args`, `cdb_grafica_scores_ttl`.
+
+Tras guardar una valoración se ejecuta el hook `cdb_grafica_after_save` y se
+invalidan los transients anteriores.

--- a/cdb-grafica.php
+++ b/cdb-grafica.php
@@ -35,6 +35,14 @@ require_once __DIR__ . '/inc/criterios-empleado.php';
 require_once __DIR__ . '/inc/grafica-empleado.php';
 // require_once __DIR__ . '/inc/shared-functions.php';
 
+// Helpers públicos cargados tras inicializar plugins.
+add_action(
+    'plugins_loaded',
+    function() {
+        require_once __DIR__ . '/inc/public-helpers.php';
+    }
+);
+
 
 // Función global para calcular el promedio de un grupo de campos.
 if (!function_exists('calcular_promedio')) {

--- a/inc/grafica-empleado.php
+++ b/inc/grafica-empleado.php
@@ -623,6 +623,14 @@ if (in_array('empleador', $roles)) {
             cdb_mails_send_new_review_notification( $row_id, 'empleado', $accion );
         }
 
+        /**
+         * Acciones tras guardar/actualizar una valoración.
+         * Permite a otros plugins reaccionar y se invalida la caché interna.
+         */
+        do_action( 'cdb_grafica_after_save', (int) $post_id );
+        delete_transient( "cdb_grafica_role_scores_{$post_id}" );
+        delete_transient( "cdb_grafica_last_rating_{$post_id}" );
+
         // Redirigir
         wp_safe_redirect( get_permalink( $post_id ) );
         exit;

--- a/inc/public-helpers.php
+++ b/inc/public-helpers.php
@@ -1,0 +1,162 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Devuelve la fecha/hora (Y-m-d H:i:s) de la última valoración para un empleado.
+ *
+ * @param int $empleado_id ID del empleado.
+ * @return string|null Fecha/hora de la última valoración o null si no hay registros.
+ */
+function cdb_grafica_get_last_rating_datetime( int $empleado_id ): ?string {
+    if ( $empleado_id <= 0 ) {
+        return null;
+    }
+
+    $cache_key = "cdb_grafica_last_rating_{$empleado_id}";
+    $cached    = get_transient( $cache_key );
+    if ( false !== $cached ) {
+        return '' === $cached ? null : $cached;
+    }
+
+    global $wpdb;
+    $table = $wpdb->prefix . 'grafica_empleado_results';
+
+    $sql_parts = apply_filters( 'cdb_grafica_last_rating_args', [
+        'where' => '',
+        'order' => '',
+    ], $empleado_id );
+
+    $sql = "SELECT MAX(created_at) FROM {$table} WHERE post_id = %d AND user_role IS NOT NULL";
+    if ( ! empty( $sql_parts['where'] ) ) {
+        $sql .= " AND {$sql_parts['where']}";
+    }
+    if ( ! empty( $sql_parts['order'] ) ) {
+        $sql .= " {$sql_parts['order']}";
+    }
+
+    $datetime = $wpdb->get_var( $wpdb->prepare( $sql, $empleado_id ) );
+
+    set_transient( $cache_key, $datetime ? $datetime : '', 600 );
+
+    return $datetime ?: null;
+}
+
+/**
+ * Devuelve totales de puntuación por rol y detalle opcional por grupos.
+ *
+ * @param int   $empleado_id ID del empleado.
+ * @param array $args        Opciones de consulta: with_detail, bypass_cache.
+ * @return array             Puntuaciones por rol y detalle si se solicita.
+ */
+function cdb_grafica_get_scores_by_role( int $empleado_id, array $args = [] ): array {
+    $defaults = [
+        'with_detail'  => false,
+        'bypass_cache' => false,
+    ];
+    $args = wp_parse_args( $args, $defaults );
+
+    $resultado_base = [ 'empleado' => null, 'empleador' => null, 'tutor' => null ];
+
+    if ( $empleado_id <= 0 ) {
+        if ( $args['with_detail'] ) {
+            $resultado_base['detalle'] = [];
+        }
+        return $resultado_base;
+    }
+
+    $transient_key = "cdb_grafica_role_scores_{$empleado_id}";
+    if ( ! $args['bypass_cache'] ) {
+        $cached = get_transient( $transient_key );
+        if ( false !== $cached ) {
+            return $cached;
+        }
+    }
+
+    global $wpdb;
+    $table = $wpdb->prefix . 'grafica_empleado_results';
+
+    $criterios = cdb_get_criterios_empleado();
+    $grupos    = [];
+    $columnas  = [];
+    foreach ( $criterios as $grupo_nombre => $campos ) {
+        $grupos[ $grupo_nombre ] = array_keys( $campos );
+        foreach ( $campos as $campo_slug => $info ) {
+            $columnas[] = $campo_slug;
+        }
+    }
+    $columnas   = array_unique( $columnas );
+    $select_cols = implode( ', ', array_merge( $columnas, [ 'created_at', 'user_role' ] ) );
+
+    $roles     = [ 'empleado', 'empleador', 'tutor' ];
+    $resultado = $resultado_base;
+    $detalle   = [];
+
+    foreach ( $roles as $rol ) {
+        $sql_parts = apply_filters( 'cdb_grafica_scores_args', [
+            'where' => '',
+            'order' => '',
+        ], $rol, $empleado_id );
+
+        $sql = "SELECT {$select_cols} FROM {$table} WHERE post_id = %d AND user_role = %s";
+        if ( ! empty( $sql_parts['where'] ) ) {
+            $sql .= " AND {$sql_parts['where']}";
+        }
+        if ( ! empty( $sql_parts['order'] ) ) {
+            $sql .= " {$sql_parts['order']}";
+        }
+
+        $rows = $wpdb->get_results( $wpdb->prepare( $sql, $empleado_id, $rol ) );
+        if ( empty( $rows ) ) {
+            $resultado[ $rol ] = null;
+            if ( $args['with_detail'] ) {
+                $detalle[ $rol ] = [ 'grupos' => [], 'total' => null ];
+            }
+            continue;
+        }
+
+        $grupos_data = [];
+        foreach ( $rows as $row ) {
+            foreach ( $grupos as $grupo_nombre => $campos ) {
+                if ( ! isset( $grupos_data[ $grupo_nombre ] ) ) {
+                    $grupos_data[ $grupo_nombre ] = [ 'suma' => 0, 'cuenta' => 0 ];
+                }
+                foreach ( $campos as $campo ) {
+                    if ( isset( $row->$campo ) && $row->$campo > 0 ) {
+                        $grupos_data[ $grupo_nombre ]['suma']   += floatval( $row->$campo );
+                        $grupos_data[ $grupo_nombre ]['cuenta'] += 1;
+                    }
+                }
+            }
+        }
+
+        $promedios = [];
+        foreach ( $grupos as $grupo_nombre => $campos ) {
+            $suma   = $grupos_data[ $grupo_nombre ]['suma'] ?? 0;
+            $cuenta = $grupos_data[ $grupo_nombre ]['cuenta'] ?? 0;
+            $avg    = $cuenta > 0 ? round( $suma / $cuenta, 1 ) : 0;
+            $codigo = strtok( $grupo_nombre, ' ' );
+            $promedios[ $codigo ] = $avg;
+        }
+
+        $total = round( array_sum( $promedios ), 1 );
+        $resultado[ $rol ] = $total;
+
+        if ( $args['with_detail'] ) {
+            $detalle[ $rol ] = [ 'grupos' => $promedios, 'total' => $total ];
+        }
+    }
+
+    if ( $args['with_detail'] ) {
+        $resultado['detalle'] = $detalle;
+    }
+
+    $ttl = intval( apply_filters( 'cdb_grafica_scores_ttl', 600, $empleado_id, $args ) );
+    if ( ! $args['bypass_cache'] ) {
+        set_transient( $transient_key, $resultado, $ttl );
+    }
+
+    return $resultado;
+}
+


### PR DESCRIPTION
## Summary
- add public helpers to retrieve last rating date and scores by role with caching
- load helpers on `plugins_loaded` and add cache invalidation hook
- document new API, transients and filters

## Testing
- `php -l inc/public-helpers.php`
- `php -l cdb-grafica.php`
- `php -l inc/grafica-empleado.php`


------
https://chatgpt.com/codex/tasks/task_e_68967d3411f48327b5ca6b6c75007b15