### PR TITLE
Expose public helpers with configurable caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,45 +33,35 @@ Al desinstalar el plugin se eliminan las tablas creadas para almacenar los resul
 
 ## API Pública
 
-El plugin expone dos helpers para que otros plugins (p.ej. `cdb-form`) puedan obtener
-información de las valoraciones de empleados sin replicar la lógica de las gráficas.
-
-### Obtener fecha de última valoración
-
-```php
-string|null cdb_grafica_get_last_rating_datetime( int $empleado_id )
-```
-
-Devuelve la fecha/hora (`Y-m-d H:i:s`) de la última valoración registrada para el
-empleado o `null` si no existen datos.
-
-### Obtener puntuaciones por rol
+El plugin expone dos helpers para que otros plugins (p.ej. `cdb-form`) puedan
+obtener información de las valoraciones de empleados sin replicar la lógica de
+las gráficas.
 
 ```php
-array cdb_grafica_get_scores_by_role( int $empleado_id, array $args = [] )
+$scores = cdb_grafica_get_scores_by_role( $empleado_id );
+$ultima = cdb_grafica_get_last_rating_datetime( $empleado_id );
 ```
 
-Retorna los totales de cada rol (`empleado`, `empleador`, `tutor`) con un decimal.
-Si se pasa `['with_detail' => true]` incluye el desglose por grupos.
+### `cdb_grafica_get_scores_by_role( int $empleado_id, array $args = [] ): array`
 
-```php
-[
-  'empleado'  => 33.1,
-  'empleador' => 28.7,
-  'tutor'     => null,
-  'detalle'   => [
-     'empleado' => ['grupos' => ['DIE' => 7.5, 'SAL' => 6.2], 'total' => 33.1],
-     'empleador'=> [...]
-  ]
-]
-```
+Devuelve un arreglo con los totales por rol (`empleado`, `empleador`, `tutor`)
+redondeados a un decimal o `0.0` si no hay datos. Acepta los argumentos:
+
+- `bypass_cache` (`bool`) para ignorar los transients.
+- `with_raw` (`bool`) para incluir el detalle intermedio ya calculado.
+
+### `cdb_grafica_get_last_rating_datetime( int $empleado_id ): ?string`
+
+Retorna la fecha/hora (`Y-m-d H:i:s`) de la última valoración registrada o
+`null` si no existen datos.
 
 ### Transients y filtros
 
-- `cdb_grafica_last_rating_{ID}` guarda la fecha de última valoración.
-- `cdb_grafica_role_scores_{ID}` almacena los totales por rol.
-- Filtros disponibles: `cdb_grafica_last_rating_args`,
-  `cdb_grafica_scores_args`, `cdb_grafica_scores_ttl`.
+- `cdb_grafica_scores_ttl` y `cdb_grafica_last_rating_ttl` permiten ajustar los
+  TTL de los transients (por defecto 600 segundos).
+- `cdb_grafica_transient_key` filtra las claves usadas para almacenar los
+  resultados (`cdbg_scores_{ID}` y `cdbg_last_{ID}`).
+- Otros filtros: `cdb_grafica_scores_args`, `cdb_grafica_last_rating_args`.
 
-Tras guardar una valoración se ejecuta el hook `cdb_grafica_after_save` y se
-invalidan los transients anteriores.
+Tras guardar una valoración se ejecuta el hook `cdb_grafica_after_save`, que
+borra los transients anteriores.

--- a/cdb-grafica.php
+++ b/cdb-grafica.php
@@ -36,12 +36,10 @@ require_once __DIR__ . '/inc/grafica-empleado.php';
 // require_once __DIR__ . '/inc/shared-functions.php';
 
 // Helpers públicos cargados tras inicializar plugins.
-add_action(
-    'plugins_loaded',
-    function() {
-        require_once __DIR__ . '/inc/public-helpers.php';
-    }
-);
+add_action( 'plugins_loaded', 'cdb_grafica_load_public_helpers' );
+function cdb_grafica_load_public_helpers(): void {
+    require_once __DIR__ . '/inc/public-helpers.php';
+}
 
 
 // Función global para calcular el promedio de un grupo de campos.

--- a/inc/grafica-empleado.php
+++ b/inc/grafica-empleado.php
@@ -628,8 +628,6 @@ if (in_array('empleador', $roles)) {
          * Permite a otros plugins reaccionar y se invalida la caché interna.
          */
         do_action( 'cdb_grafica_after_save', (int) $post_id );
-        delete_transient( "cdb_grafica_role_scores_{$post_id}" );
-        delete_transient( "cdb_grafica_last_rating_{$post_id}" );
 
         // Redirigir
         wp_safe_redirect( get_permalink( $post_id ) );


### PR DESCRIPTION
## Summary
- add `cdb_grafica_get_scores_by_role()` and `cdb_grafica_get_last_rating_datetime()` helpers with transient cache and filters
- load helpers on `plugins_loaded`
- document public API, filters and invalidation hooks

## Testing
- `php -l inc/public-helpers.php`
- `php -l cdb-grafica.php`
- `php -l inc/grafica-empleado.php`


------
https://chatgpt.com/codex/tasks/task_e_68970e23eadc8327acefe8e05166f61c