### PR TITLE
feat: improve scores table accessibility

### DIFF
--- a/inc/grafica-empleado.php
+++ b/inc/grafica-empleado.php
@@ -624,6 +624,13 @@ function cdb_grafica_build_empleado_scores_table_html( int $empleado_id, array $
     ob_start();
     ?>
     <table class="cdb-grafica-scores">
+        <caption class="screen-reader-text"><?php esc_html_e( 'Tabla de calificaciones por criterio y rol', 'cdb-grafica' ); ?></caption>
+        <colgroup>
+            <col style="width:40%">
+            <col style="width:20%">
+            <col style="width:20%">
+            <col style="width:20%">
+        </colgroup>
         <thead>
             <tr>
                 <th><?php esc_html_e( 'Criterio', 'cdb-grafica' ); ?></th>
@@ -637,7 +644,7 @@ function cdb_grafica_build_empleado_scores_table_html( int $empleado_id, array $
             <tr>
                 <th scope="row"><?php echo esc_html( $grupo_nombre ); ?></th>
                 <?php foreach ( $roles as $role ) : ?>
-                    <td><?php echo '' !== $scores[ $role ][ $grupo_nombre ] ? esc_html( $scores[ $role ][ $grupo_nombre ] ) : '-'; ?></td>
+                    <td class="is-numeric"><?php echo '' !== $scores[ $role ][ $grupo_nombre ] ? esc_html( $scores[ $role ][ $grupo_nombre ] ) : '-'; ?></td>
                 <?php endforeach; ?>
             </tr>
         <?php endforeach; ?>

--- a/style.css
+++ b/style.css
@@ -64,3 +64,7 @@ form {
     border-radius: 5px; /* Bordes redondeados */
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); /* Sombra suave */
 }
+
+.cdb-grafica-scores td.is-numeric {
+    font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
## Summary
- add accessible caption and column group to scores table
- apply `is-numeric` class and tabular numeric styling

## Testing
- `php -l inc/grafica-empleado.php`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c5f2dcee08327b48a7becdb94a82f