### PR TITLE
feat: add read-only employee score accordion

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -16,3 +16,24 @@ body {
     border-radius: 3px;
     display: inline-block;
 }
+
+/* Badges de valores por rol (modo lectura) */
+.cdb-score-badge{
+  display:inline-block;
+  min-width:2.25rem;
+  padding:.25rem .5rem;
+  margin-right:.5rem;
+  text-align:center;
+  border-radius:.5rem;
+  font-weight:600;
+  line-height:1;
+}
+.cdb-readonly-row{
+  display:flex;
+  gap:.5rem;
+  align-items:center;
+  padding:.5rem 0;
+}
+
+/* Mantener consistencia con el acordeón existente */
+.accordion-content{ padding:.75rem 1rem; }


### PR DESCRIPTION
## Summary
- add helper to render employee scores in a read-only accordion with badges per role
- style badges and accordion content for readonly view

## Testing
- `php -l inc/grafica-empleado.php`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689e1bc8d67483278cd4ce2d4d205877