### PR TITLE
Add read‑only employee score accordion

### DIFF
--- a/style.css
+++ b/style.css
@@ -82,3 +82,13 @@ form {
     border-radius: 3px;
     display: inline-block;
 }
+
+.cdb-readonly .accordion-item{ background:#faf7ef;border:1px solid rgba(0,0,0,.08);border-radius:10px;margin-bottom:10px; }
+.cdb-readonly .accordion-header{ padding:12px 14px; }
+.cdb-readonly .accordion-content{ padding:10px 14px 14px; }
+.cdb-readonly-row{ display:flex; align-items:center; justify-content:space-between; gap:12px; padding:8px 0; }
+.cdb-readonly-label{ font-weight:600; }
+.cdb-score-pills{ display:flex; gap:8px; }
+.cdb-score-pill{ display:inline-flex; align-items:center; justify-content:center; min-width:2.6ch; height:1.9em; padding:0 .55ch; border-radius:6px; font-weight:700; line-height:1; font-variant-numeric:tabular-nums; border:1px solid currentColor; }
+.cdb-score-pill.is-empty{ opacity:.75; }
+@media (max-width:480px){ .cdb-readonly-row{ flex-wrap:wrap; } }


### PR DESCRIPTION
## Summary
- Implement read-only accordion HTML generator for employee scores with legend and role-based color pills
- Register provider filter and enqueue shared assets
- Add styles for new read-only accordion components

## Testing
- `php -l inc/grafica-empleado.php`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a1171232b08327814adb25f0bc05fb