### PR TITLE
Style: unify accordion & scores table visuals

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -16,3 +16,119 @@ body {
     border-radius: 3px;
     display: inline-block;
 }
+/* === CDB_grafica – Accordion (shared by form & readonly) === */
+.accordion{
+  display:block;
+  margin:16px 0 24px;
+}
+.accordion .accordion-item{
+  border:1px solid rgba(0,0,0,.08);
+  border-radius:12px;
+  margin:0 0 12px;
+  background:#fff;
+  overflow:hidden;
+}
+.accordion .accordion-header{
+  display:flex;
+  align-items:center;
+  min-height:56px;
+  padding:14px 16px;
+}
+.accordion .accordion-toggle{
+  all:unset;
+  cursor:pointer;
+  display:flex;
+  align-items:center;
+  width:100%;
+  font-weight:600;
+  font-size:1.05rem;
+  line-height:1.3;
+}
+/* Caret indicator (abre/cierra). 
+   Compatible con .accordion-toggle.open y .accordion-header.open */
+.accordion .accordion-toggle::after{
+  content:"";
+  margin-left:auto;
+  width:9px; height:9px;
+  border-right:2px solid currentColor;
+  border-bottom:2px solid currentColor;
+  transform:rotate(-45deg); /* flecha a la derecha */
+  transition:transform .2s ease;
+}
+.accordion .accordion-toggle.open::after,
+.accordion .accordion-header.open .accordion-toggle::after{
+  transform:rotate(45deg); /* flecha hacia abajo */
+}
+
+.accordion .accordion-content{
+  display:none;              /* el JS hace slideToggle */
+  padding:12px 16px 16px;
+  border-top:1px solid rgba(0,0,0,.06);
+}
+.accordion .accordion-content label{
+  display:block;
+  margin:0 0 8px;
+  font-weight:600;
+}
+.accordion .accordion-content em{
+  color:#666;
+  font-style:normal;
+  font-weight:500;
+}
+.accordion input[type="range"]{
+  width:100%;
+}
+
+/* === Legend tweaks (roles) – mayor coherencia visual === */
+.cdb-scores-legend{
+  display:flex;
+  gap:12px;
+  align-items:center;
+  margin:12px 0 8px;
+}
+.cdb-scores-legend .role{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  font-size:.95rem;
+  color:#333;
+}
+.cdb-scores-legend .role i{
+  width:12px; height:12px;
+  border-radius:3px;
+  display:inline-block;
+}
+
+/* === Aggregated scores table (tabla de medias por rol) === */
+table.cdb-grafica-scores{
+  width:100%;
+  table-layout:fixed;
+  border-collapse:collapse;
+}
+.cdb-grafica-scores thead th{
+  font-weight:600;
+  text-align:center;
+  padding:10px 8px;
+}
+.cdb-grafica-scores thead th:first-child{
+  text-align:left;
+}
+.cdb-grafica-scores tbody th[scope="row"]{
+  text-align:left;
+  padding:12px 8px;
+}
+.cdb-grafica-scores tbody td{
+  text-align:center;
+  padding:12px 8px;
+  vertical-align:middle;
+}
+.cdb-grafica-scores tbody tr + tr td,
+.cdb-grafica-scores tbody tr + tr th{
+  border-top:1px dashed rgba(0,0,0,.08);
+}
+
+/* === Mobile polish === */
+@media (max-width:640px){
+  .accordion .accordion-header{ padding:12px 14px; }
+  .accordion .accordion-content{ padding:10px 14px 14px; }
+}


### PR DESCRIPTION
## Summary
- align read-only and interactive profiles with unified accordion styling, caret indicator, and mobile spacing
- tweak role legend layout and colors for consistent visuals
- style aggregated scores table with centered data and dashed row separators

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a11ef3b9b883278e3c0edd86c6627c