### PR TITLE
Align accordion and pill styles

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -10,17 +10,17 @@ body {
 }
 
 /* Consistencia de espacios */
-.accordion { margin: 16px 0; border:1px solid #cdb888; border-radius:10px; overflow:hidden; }
-.accordion-header { background:#FAF8EE; padding:12px 14px; cursor:pointer; border-bottom:1px solid #cdb888; font-weight:600; }
-.accordion-content { display:none; padding:12px 14px 14px; background:#FAF8EE; }
+.accordion { margin:16px 0; border:1px solid #e0d6b8; border-radius:12px; overflow:hidden; }
+.accordion-header { background:#FAF8EE; padding:14px 16px; cursor:pointer; border-bottom:1px solid #e0d6b8; font-weight:600; }
+.accordion-content { display:none; padding:14px 16px; background:#FAF8EE; }
 
 /* Readonly: items con la misma cadencia visual que form */
 .cdb-readonly .accordion-item {
   background:#FAF8EE;
-  border-bottom:1px solid rgba(0,0,0,.06);
-  margin:0; /* se hereda el margen del contenedor principal */
+  border:1px solid rgba(0,0,0,.08);
+  border-radius:12px;
+  margin:10px 0;
 }
-.cdb-readonly .accordion-item:last-child { border-bottom:0; }
 
 /* Filas de readonly */
 .cdb-readonly-row{ display:flex; align-items:center; justify-content:space-between; gap:12px; padding:8px 0; }
@@ -30,10 +30,13 @@ body {
 .cdb-score-pills{ display:flex; gap:8px; }
 .cdb-score-pill{
   display:inline-flex; align-items:center; justify-content:center;
-  min-width:2.6ch; height:1.9em; padding:0 .55ch; border-radius:6px;
+  min-width:3.2ch; height:2.0em; padding:0 .6ch; border-radius:7px;
   font-weight:700; line-height:1; font-variant-numeric:tabular-nums; border:1px solid currentColor;
 }
 .cdb-score-pill.is-empty{ opacity:.75; }
+.cdb-score-pill.role-emp{ color:#4bc0c0; }
+.cdb-score-pill.role-empdr{ color:#36a2eb; }
+.cdb-score-pill.role-tutor{ color:#ff6384; }
 
 /* Leyenda compacta y alineada con card */
 .cdb-scores-legend{ display:flex; gap:12px; align-items:center; margin:8px 0 12px; }

--- a/script.js
+++ b/script.js
@@ -1,16 +1,18 @@
 jQuery(document).ready(function ($) {
-    $('.accordion-toggle').on('click', function () {
-        const accordion = $(this).closest('.accordion');
-        const content = accordion.find('.accordion-content');
+  $('.accordion-toggle').on('click', function () {
+    const accordion = $(this).closest('.accordion');
+    const header    = accordion.find('.accordion-header').first();
+    const content   = accordion.find('.accordion-content').first();
 
-        // Alternar la visibilidad del contenido
-        content.slideToggle(300); // Animación de 300ms
+    content.slideToggle(300);
+    $(this).toggleClass('open');
+    header.toggleClass('open');
 
-        // Cambiar clase para estilos de encabezado abierto/cerrado
-        $(this).toggleClass('open');
-
-        // Opcional: cerrar otros acordeones abiertos
-        // $('.accordion').not(accordion).find('.accordion-content').slideUp(300);
-        // $('.accordion').not(accordion).find('.accordion-toggle').removeClass('open');
-    });
+    // Si quieres cerrar los demás, descomenta:
+    // $('.accordion').not(accordion).each(function(){
+    //   $(this).find('.accordion-content').slideUp(300);
+    //   $(this).find('.accordion-toggle').removeClass('open');
+    //   $(this).find('.accordion-header').removeClass('open');
+    // });
+  });
 });

--- a/style.css
+++ b/style.css
@@ -1,24 +1,17 @@
 /* Estilos para la tabla con acordeón */
 .accordion {
-    margin: 1em 0; /* Margen superior e inferior */
-    border: 1px solid #cdb888;
-    border-radius: 5px;
-    overflow: hidden;
+    margin: 16px 0;
+    border:1px solid #e0d6b8;
+    border-radius:12px;
+    overflow:hidden;
 }
 
 .accordion-header {
-    background-color: #FAF8EE; /* Fondo blanco */
-    padding: 10px 15px;
-    cursor: pointer;
-    border-bottom: 1px solid #cdb888;
-    color: #000; /* Texto negro */
-    font-weight: bold;
-    border-radius: 5px; /* Bordes redondeados */
-    transition: background-color 0.3s ease, color 0.3s ease; /* Transición suave */
-}
-
-.accordion-header:hover {
-    background-color: #cdb121; /* Fondo más oscuro al pasar el ratón */
+    background:#FAF8EE;
+    padding:14px 16px;
+    cursor:pointer;
+    border-bottom:1px solid #e0d6b8;
+    font-weight:600;
 }
 
 .accordion-header .accordion-toggle {
@@ -34,9 +27,9 @@
 }
 
 .accordion-content {
-    display: none;
-    padding: 15px;
-    background-color: #FAF8EE; /* Fondo blanco */
+    display:none;
+    padding:14px 16px;
+    background:#FAF8EE;
 }
 
 .accordion-content label {
@@ -83,12 +76,18 @@ form {
     display: inline-block;
 }
 
-.cdb-readonly .accordion-item{ background:#faf7ef;border:1px solid rgba(0,0,0,.08);border-radius:10px;margin-bottom:10px; }
-.cdb-readonly .accordion-header{ padding:12px 14px; }
-.cdb-readonly .accordion-content{ padding:10px 14px 14px; }
+.cdb-readonly .accordion-item{
+    background:#FAF8EE;
+    border:1px solid rgba(0,0,0,.08);
+    border-radius:12px;
+    margin:10px 0;
+}
 .cdb-readonly-row{ display:flex; align-items:center; justify-content:space-between; gap:12px; padding:8px 0; }
 .cdb-readonly-label{ font-weight:600; }
 .cdb-score-pills{ display:flex; gap:8px; }
-.cdb-score-pill{ display:inline-flex; align-items:center; justify-content:center; min-width:2.6ch; height:1.9em; padding:0 .55ch; border-radius:6px; font-weight:700; line-height:1; font-variant-numeric:tabular-nums; border:1px solid currentColor; }
+.cdb-score-pill{ display:inline-flex; align-items:center; justify-content:center; min-width:3.2ch; height:2.0em; padding:0 .6ch; border-radius:7px; font-weight:700; line-height:1; font-variant-numeric:tabular-nums; border:1px solid currentColor; }
 .cdb-score-pill.is-empty{ opacity:.75; }
+.cdb-score-pill.role-emp{ color:#4bc0c0; }
+.cdb-score-pill.role-empdr{ color:#36a2eb; }
+.cdb-score-pill.role-tutor{ color:#ff6384; }
 @media (max-width:480px){ .cdb-readonly-row{ flex-wrap:wrap; } }


### PR DESCRIPTION
## Summary
- toggle header's open state with accordion button
- align accordion container and header spacing and borders with form
- enlarge readonly score pills and add role-based color hints

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a26b98e69c83279e9268f594f89411