### PR TITLE
style: add group header styles for scores table

### DIFF
--- a/style.css
+++ b/style.css
@@ -102,5 +102,11 @@ form {
 .cdb-scores-title { font-weight:700; text-align:left; margin-bottom:4px; }
 
 /* Estilos para la tabla de promedios */
-.cdb-grafica-scores .group-header th { font-weight:700; text-align:left; }
+.cdb-grafica-scores .group-header th {
+    background:#cdb121;
+    color:#000;
+    font-weight:700;
+    padding:.25em .5em;
+    text-align:left;
+}
 .cdb-grafica-scores .score-cell { text-align:center; }


### PR DESCRIPTION
## Summary
- style group header in scores table with custom background, text color, and padding

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a35549a58c8327b6f4765e1fd12a33