### PR TITLE
Remove roles header from employee score table

### DIFF
--- a/inc/grafica-empleado.php
+++ b/inc/grafica-empleado.php
@@ -673,14 +673,6 @@ function cdb_grafica_build_empleado_scores_table_html( int $empleado_id, array $
             <col class="col-empdr" style="width:20%">
             <col class="col-tutor" style="width:20%">
         </colgroup>
-        <thead>
-            <tr>
-                <th><?php esc_html_e( 'Criterio', 'cdb-grafica' ); ?></th>
-                <th><?php echo esc_html( cdb_empleado_plural_role( 'empleado' ) ); ?></th>
-                <th><?php echo esc_html( cdb_empleado_plural_role( 'empleador' ) ); ?></th>
-                <th><?php echo esc_html( cdb_empleado_plural_role( 'tutor' ) ); ?></th>
-            </tr>
-        </thead>
         <tbody>
         <?php foreach ( $criterios as $grupo_nombre => $campos ) : ?>
             <tr class="group-header">

--- a/style.css
+++ b/style.css
@@ -102,6 +102,15 @@ form {
 .cdb-scores-title { font-weight:700; text-align:left; margin-bottom:4px; }
 
 /* Estilos para la tabla de promedios */
+.cdb-grafica-scores {
+    border-collapse: collapse;
+}
+
+.cdb-grafica-scores th,
+.cdb-grafica-scores td {
+    padding:.25em .5em;
+}
+
 .cdb-grafica-scores .group-header th {
     background:#cdb121;
     color:#000;


### PR DESCRIPTION
## Summary
- drop table header from employee scores table to rely on legend for role colors
- collapse table borders and set cell padding for tighter layout

## Testing
- `php -l inc/grafica-empleado.php`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a358b3a3b48327b094c6b3290c2627