### PR TITLE
Estilos para celdas de criterios en tabla de puntuaciones

### DIFF
--- a/inc/grafica-empleado.php
+++ b/inc/grafica-empleado.php
@@ -680,10 +680,10 @@ function cdb_grafica_build_empleado_scores_table_html( int $empleado_id, array $
             </tr>
             <?php foreach ( $campos as $campo_slug => $info ) : ?>
                 <tr>
-                    <th scope="row">
+                    <th scope="row" class="criterio-cell">
                         <?php echo esc_html( $info['label'] ); ?>
                         <?php if ( ! empty( $info['descripcion'] ) ) : ?>
-                            <br><small><?php echo esc_html( $info['descripcion'] ); ?></small>
+                            <small><?php echo esc_html( $info['descripcion'] ); ?></small>
                         <?php endif; ?>
                     </th>
                     <?php foreach ( $roles as $rol ) : ?>

--- a/style.css
+++ b/style.css
@@ -111,11 +111,22 @@ form {
     padding:.25em .5em;
 }
 
+.cdb-grafica-scores th.criterio-cell {
+    text-align:left;
+    padding-left:0;
+    display:flex;
+    flex-direction:column;
+    align-items:flex-start;
+}
+
+.cdb-grafica-scores th.criterio-cell small { margin:2px 0 0; }
+
 .cdb-grafica-scores .group-header th {
     background:#cdb121;
     color:#000;
     font-weight:700;
     padding:.25em .5em;
+    padding-left:0;
     text-align:left;
 }
 .cdb-grafica-scores .score-cell { text-align:center; }


### PR DESCRIPTION
## Summary
- Añade clase `criterio-cell` a los encabezados de criterios en la tabla de puntuaciones.
- Alinea a la izquierda y sin padding las celdas de criterios y cabeceras de grupo, con soporte para disposición en columna.
- Ajusta el margen de las descripciones para alinearlas con sus etiquetas.

## Testing
- `npm test` *(falla: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a43d988be8832785e20db51a651e90