### PR TITLE
Adjust employee score table column widths

### DIFF
--- a/inc/grafica-empleado.php
+++ b/inc/grafica-empleado.php
@@ -668,10 +668,10 @@ function cdb_grafica_build_empleado_scores_table_html( int $empleado_id, array $
                   --color-tutor:<?php echo esc_attr( $c_tutor ); ?>;">
         <caption class="cdb-scores-title"><?php esc_html_e( 'Tus calificaciones:', 'cdb-grafica' ); ?></caption>
         <colgroup>
-            <col class="col-criterio" style="width:40%">
-            <col class="col-emp" style="width:20%">
-            <col class="col-empdr" style="width:20%">
-            <col class="col-tutor" style="width:20%">
+            <col class="col-criterio" style="width:auto">
+            <col class="col-emp" style="width:3ch">
+            <col class="col-empdr" style="width:3ch">
+            <col class="col-tutor" style="width:3ch">
         </colgroup>
         <tbody>
         <?php foreach ( $criterios as $grupo_nombre => $campos ) : ?>

--- a/style.css
+++ b/style.css
@@ -130,3 +130,8 @@ form {
     text-align:left;
 }
 .cdb-grafica-scores .score-cell { text-align:center; }
+
+.cdb-grafica-scores .col-emp,
+.cdb-grafica-scores .col-empdr,
+.cdb-grafica-scores .col-tutor { width:3ch; }
+.cdb-grafica-scores .col-criterio { width:auto; }


### PR DESCRIPTION
## Summary
- Narrow score columns in employee table to fixed 3ch width and let criteria column auto-expand
- Add CSS fallbacks for column widths in score tables

## Testing
- `php -l inc/grafica-empleado.php`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a43f219e20832797c4b21478f307a5