### PR TITLE
Add grouped accordions for employee score table

### DIFF
--- a/inc/grafica-empleado.php
+++ b/inc/grafica-empleado.php
@@ -673,10 +673,10 @@ function cdb_grafica_build_empleado_scores_table_html( int $empleado_id, array $
             <col class="col-empdr" style="width:3ch">
             <col class="col-tutor" style="width:3ch">
         </colgroup>
-        <tbody>
         <?php foreach ( $criterios as $grupo_nombre => $campos ) : ?>
+        <tbody class="grupo">
             <tr class="group-header">
-                <th colspan="4"><?php echo esc_html( $grupo_nombre ); ?></th>
+                <th colspan="4"><button class="group-toggle" type="button"><?php echo esc_html( $grupo_nombre ); ?></button></th>
             </tr>
             <?php foreach ( $campos as $campo_slug => $info ) : ?>
                 <tr>
@@ -691,8 +691,8 @@ function cdb_grafica_build_empleado_scores_table_html( int $empleado_id, array $
                     <?php endforeach; ?>
                 </tr>
             <?php endforeach; ?>
-        <?php endforeach; ?>
         </tbody>
+        <?php endforeach; ?>
     </table>
     <?php
     return ob_get_clean();

--- a/script.js
+++ b/script.js
@@ -13,4 +13,9 @@ jQuery(document).ready(function ($) {
         // $('.accordion').not(accordion).find('.accordion-content').slideUp(300);
         // $('.accordion').not(accordion).find('.accordion-toggle').removeClass('open');
     });
+
+    $('.cdb-grafica-scores .group-toggle').on('click', function(){
+        const section = $(this).closest('tbody');
+        section.toggleClass('is-open');
+    });
 });

--- a/style.css
+++ b/style.css
@@ -129,6 +129,15 @@ form {
     padding-left:0;
     text-align:left;
 }
+.cdb-grafica-scores .group-toggle {
+    all:unset;
+    display:block;
+    width:100%;
+    text-align:left;
+    cursor:pointer;
+}
+
+.cdb-grafica-scores tbody:not(.is-open) tr:not(.group-header) { display:none; }
 .cdb-grafica-scores .score-cell { text-align:center; }
 
 .cdb-grafica-scores .col-emp,


### PR DESCRIPTION
## Summary
- Render employee score tables with a `<tbody>` per group and toggle buttons for each header
- Hide score rows by default and style group toggle buttons
- Toggle groups open/closed independently with new jQuery handler

## Testing
- `php -l inc/grafica-empleado.php`
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: wp-scripts: not found)*
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden to @wordpress/scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68a44052142c8327962e738016530652