### PR TITLE
Improve accordion toggle behavior

### DIFF
--- a/inc/grafica-empleado.php
+++ b/inc/grafica-empleado.php
@@ -795,7 +795,7 @@ function cdb_grafica_build_empleado_readonly_html( $empleado_id, $args = array()
       <div class="accordion-header">
         <button class="accordion-toggle" type="button"><?php echo esc_html( $grupo_data['label'] ); ?></button>
       </div>
-      <div class="accordion-content" style="display:none;">
+      <div class="accordion-content">
         <?php foreach ( $grupo_data['campos'] as $campo_slug => $campo_info ): ?>
           <div class="cdb-readonly-row">
             <span class="cdb-readonly-label"><?php echo esc_html( $campo_info['label'] ); ?></span>

--- a/script.js
+++ b/script.js
@@ -1,17 +1,10 @@
 jQuery(document).ready(function ($) {
-    $('.accordion-toggle').on('click', function () {
-        const accordion = $(this).closest('.accordion');
-        const content = accordion.find('.accordion-content');
-
-        // Alternar la visibilidad del contenido
-        content.slideToggle(300); // Animación de 300ms
-
-        // Cambiar clase para estilos de encabezado abierto/cerrado
-        $(this).toggleClass('open');
-
-        // Opcional: cerrar otros acordeones abiertos
-        // $('.accordion').not(accordion).find('.accordion-content').slideUp(300);
-        // $('.accordion').not(accordion).find('.accordion-toggle').removeClass('open');
+    $('.accordion.cdb-readonly .accordion-toggle').on('click', function () {
+        const item = $(this).closest('.accordion-item');
+        const content = item.find('> .accordion-content');
+        content.slideToggle(300);            // sólo el grupo pulsado
+        $(this).toggleClass('open');         // estilo para encabezado activo
+        item.toggleClass('open');            // (opcional) marcar el grupo
     });
 
     $('.cdb-grafica-scores .group-toggle').on('click', function(){

--- a/style.css
+++ b/style.css
@@ -28,16 +28,14 @@
     text-align: left;
 }
 
-.accordion-header.open {
-    background-color: #000; /* Fondo negro cuando está abierto */
-    color: #fff; /* Texto blanco cuando está abierto */
-}
-
 .accordion-content {
     display: none;
     padding: 15px;
     background-color: #FAF8EE; /* Fondo blanco */
 }
+
+.accordion-item.open > .accordion-content { display: block; }
+.accordion-item.open > .accordion-header { background:#000; color:#fff; }
 
 .accordion-content label {
     display: block;


### PR DESCRIPTION
## Summary
- Limit readonly accordion buttons to only toggle their own group
- Style readonly accordion items via CSS instead of inline display attributes
- Highlight active readonly accordion headers

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a444af244c8327a0988b8086562eed