### PR TITLE
Improve group toggle accessibility

### DIFF
--- a/inc/grafica-empleado.php
+++ b/inc/grafica-empleado.php
@@ -687,7 +687,11 @@ function cdb_grafica_build_empleado_scores_table_html( int $empleado_id, array $
         <?php foreach ( $criterios as $grupo_nombre => $campos ) : ?>
         <tbody class="grupo">
             <tr class="group-header">
-                <th colspan="4"><button class="group-toggle" type="button"><?php echo esc_html( $grupo_nombre ); ?></button></th>
+                <th colspan="4">
+                    <button class="group-toggle" type="button" aria-expanded="false">
+                        <?php echo esc_html( $grupo_nombre ); ?>
+                    </button>
+                </th>
             </tr>
             <?php foreach ( $campos as $campo_slug => $info ) : ?>
                 <tr>

--- a/script.js
+++ b/script.js
@@ -9,6 +9,7 @@ jQuery(document).ready(function ($) {
 
     $('.cdb-grafica-scores .group-toggle').on('click', function(){
         const section = $(this).closest('tbody');
-        section.toggleClass('is-open');
+        const isOpen = section.toggleClass('is-open').hasClass('is-open');
+        $(this).attr('aria-expanded', isOpen);
     });
 });

--- a/style.css
+++ b/style.css
@@ -133,6 +133,20 @@ form {
     width:100%;
     text-align:left;
     cursor:pointer;
+    position:relative;
+    padding-right:1.5em;
+}
+
+.cdb-grafica-scores .group-toggle::after {
+    content:"\25B6";
+    position:absolute;
+    right:.4em;
+    top:50%;
+    transform:translateY(-50%);
+    transition:transform .2s;
+}
+.cdb-grafica-scores tbody.is-open .group-toggle::after {
+    transform:translateY(-50%) rotate(90deg);
 }
 
 .cdb-grafica-scores tbody:not(.is-open) tr:not(.group-header) { display:none; }


### PR DESCRIPTION
## Summary
- add dynamic `aria-expanded` to employee graph group headers
- sync toggle state with JS and show rotating triangle indicator

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a519a7ff088327ace31b5f0db51a56