### PR TITLE
Use left-aligned ::before indicator for group toggles

### DIFF
--- a/style.css
+++ b/style.css
@@ -134,18 +134,18 @@ form {
     text-align:left;
     cursor:pointer;
     position:relative;
-    padding-right:1.5em;
+    padding-left:1.5em;
 }
 
-.cdb-grafica-scores .group-toggle::after {
+.cdb-grafica-scores .group-toggle::before {
     content:"\25B6";
     position:absolute;
-    right:.4em;
+    left:.4em;
     top:50%;
     transform:translateY(-50%);
     transition:transform .2s;
 }
-.cdb-grafica-scores tbody.is-open .group-toggle::after {
+.cdb-grafica-scores tbody.is-open .group-toggle::before {
     transform:translateY(-50%) rotate(90deg);
 }
 


### PR DESCRIPTION
## Summary
- Position group toggle icons on the left by replacing `padding-right` with `padding-left`
- Switch to `::before` pseudo-element and update styles so the indicator aligns to the left

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: wp-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a51b13354083278eaba9f115f19fda