### PR TITLE
Add empleado score API helpers

### DIFF
--- a/cdb-grafica.php
+++ b/cdb-grafica.php
@@ -39,6 +39,7 @@ require_once __DIR__ . '/inc/grafica-empleado.php';
 add_action( 'plugins_loaded', 'cdb_grafica_load_public_helpers' );
 function cdb_grafica_load_public_helpers(): void {
     require_once __DIR__ . '/inc/public-helpers.php';
+    require_once __DIR__ . '/inc/api-empleado.php';
 }
 
 

--- a/inc/api-empleado.php
+++ b/inc/api-empleado.php
@@ -1,0 +1,68 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+// inc/api-empleado.php
+
+/**
+ * Obtiene el total de puntuación para el rol empleado.
+ *
+ * @param int $empleado_id ID del empleado.
+ * @return float Total de puntuación.
+ */
+function cdb_grafica_get_empleado_total( int $empleado_id ): float {
+    if ( $empleado_id <= 0 ) {
+        return 0.0;
+    }
+
+    $cache_key = apply_filters( 'cdb_grafica_transient_key', "cdbg_etotal_{$empleado_id}", $empleado_id, 'empleado_total' );
+    $cached    = get_transient( $cache_key );
+    if ( false !== $cached ) {
+        return (float) $cached;
+    }
+
+    $scores = cdb_grafica_get_scores_by_role( $empleado_id, [ 'role' => 'empleado', 'with_raw' => true ] );
+    $total  = 0.0;
+    if ( isset( $scores['raw']['empleado']['total'] ) ) {
+        $total = (float) $scores['raw']['empleado']['total'];
+    }
+
+    $total = apply_filters( 'cdb_grafica_empleado_total', $total, $empleado_id );
+
+    $ttl = (int) apply_filters( 'cdb_grafica_scores_ttl', 600, $empleado_id );
+    set_transient( $cache_key, $total, $ttl );
+
+    return $total;
+}
+
+/**
+ * Obtiene los promedios por grupo para el rol empleado.
+ *
+ * @param int $empleado_id ID del empleado.
+ * @return array Promedios por grupo.
+ */
+function cdb_grafica_get_empleado_group_avgs( int $empleado_id ): array {
+    if ( $empleado_id <= 0 ) {
+        return [];
+    }
+
+    $cache_key = apply_filters( 'cdb_grafica_transient_key', "cdbg_eavgs_{$empleado_id}", $empleado_id, 'empleado_group_avgs' );
+    $cached    = get_transient( $cache_key );
+    if ( false !== $cached ) {
+        return (array) $cached;
+    }
+
+    $scores = cdb_grafica_get_scores_by_role( $empleado_id, [ 'role' => 'empleado', 'with_raw' => true ] );
+    $avgs   = [];
+    if ( isset( $scores['raw']['empleado']['grupos'] ) && is_array( $scores['raw']['empleado']['grupos'] ) ) {
+        $avgs = $scores['raw']['empleado']['grupos'];
+    }
+
+    $avgs = apply_filters( 'cdb_grafica_empleado_group_avgs', $avgs, $empleado_id );
+
+    $ttl = (int) apply_filters( 'cdb_grafica_scores_ttl', 600, $empleado_id );
+    set_transient( $cache_key, $avgs, $ttl );
+
+    return $avgs;
+}


### PR DESCRIPTION
## Summary
- implement functions to retrieve empleado total score and group averages with caching and filters
- load the new empleado API helpers when the plugin initializes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a523b694808327bc34cdf4abab5d2c