### PR TITLE
Load empleado API

### DIFF
--- a/cdb-grafica.php
+++ b/cdb-grafica.php
@@ -33,6 +33,7 @@ require_once __DIR__ . '/inc/criterios-bar.php';
 require_once __DIR__ . '/inc/grafica-bar.php';
 require_once __DIR__ . '/inc/criterios-empleado.php';
 require_once __DIR__ . '/inc/grafica-empleado.php';
+require_once __DIR__ . '/inc/api-empleado.php';
 // require_once __DIR__ . '/inc/shared-functions.php';
 
 // Helpers públicos cargados tras inicializar plugins.


### PR DESCRIPTION
## Summary
- load empleado API when initializing plugin

## Testing
- `php -l cdb-grafica.php`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a524be77d08327843436aa5d01cadf