### PR TITLE
Clear employee transients on save

### DIFF
--- a/inc/public-helpers.php
+++ b/inc/public-helpers.php
@@ -206,8 +206,13 @@ add_action(
     function ( int $empleado_id ): void {
         $scores_key = apply_filters( 'cdb_grafica_transient_key', "cdbg_scores_{$empleado_id}", $empleado_id, 'scores' );
         $last_key   = apply_filters( 'cdb_grafica_transient_key', "cdbg_last_{$empleado_id}", $empleado_id, 'last' );
+        $etotal_key = apply_filters( 'cdb_grafica_transient_key', "cdbg_etotal_{$empleado_id}", $empleado_id, 'empleado_total' );
+        $eavgs_key  = apply_filters( 'cdb_grafica_transient_key', "cdbg_eavgs_{$empleado_id}", $empleado_id, 'empleado_group_avgs' );
+
         delete_transient( $scores_key );
         delete_transient( $last_key );
+        delete_transient( $etotal_key );
+        delete_transient( $eavgs_key );
     }
 );
 


### PR DESCRIPTION
## Summary
- purge cached score, last rating, total, and group average transients when an employee is saved

## Testing
- `php -l inc/public-helpers.php`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5262018508327a66f9068ea2e3a8c