### PR TITLE
Restore shared functions for criteria table

### DIFF
--- a/cdb-grafica.php
+++ b/cdb-grafica.php
@@ -34,7 +34,7 @@ require_once __DIR__ . '/inc/grafica-bar.php';
 require_once __DIR__ . '/inc/criterios-empleado.php';
 require_once __DIR__ . '/inc/grafica-empleado.php';
 require_once __DIR__ . '/inc/api-empleado.php';
-// require_once __DIR__ . '/inc/shared-functions.php';
+require_once __DIR__ . '/inc/shared-functions.php';
 
 // Helpers públicos cargados tras inicializar plugins.
 add_action( 'plugins_loaded', 'cdb_grafica_load_public_helpers' );


### PR DESCRIPTION
## Summary
- load `inc/shared-functions.php` to restore criteria table functionality

## Testing
- `php -l cdb-grafica.php`
- `php -l inc/shared-functions.php`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a59949d2808327aac6fdffd6be347e