### PR TITLE
Expand accordion toggle selector

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,6 +1,6 @@
 jQuery(document).ready(function ($) {
-    $('.accordion.cdb-readonly .accordion-toggle').on('click', function () {
-        const item = $(this).closest('.accordion-item');
+    $('.accordion .accordion-toggle').on('click', function () {
+        const item = $(this).closest('.accordion-item, .accordion');
         const content = item.find('> .accordion-content');
         content.slideToggle(300);            // sólo el grupo pulsado
         $(this).toggleClass('open');         // estilo para encabezado activo


### PR DESCRIPTION
## Summary
- handle clicks for any accordion toggle and not just cdb-readonly
- search nearest accordion parent when toggling accordion content

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a59c3140a8832799b9ef7814e1341d