### PR TITLE
feat: add reusable radar render hook

### DIFF
--- a/inc/grafica-empleado.php
+++ b/inc/grafica-empleado.php
@@ -110,6 +110,136 @@ function cdb_grafica_empleado_shortcode( $atts ): string {
 add_shortcode( 'cdb_grafica_empleado', 'cdb_grafica_empleado_shortcode' );
 
 // ------------------------------------------------------------------
+// Hook reutilizable para la gráfica radar del empleado.
+// ------------------------------------------------------------------
+if ( ! function_exists( 'cdb_grafica_output_radar_empleado' ) ) {
+    /**
+     * Imprime el canvas y la configuración de Chart.js para el radar de un empleado.
+     *
+     * @param int $empleado_id ID del empleado.
+     */
+    function cdb_grafica_output_radar_empleado( $empleado_id ) {
+        $empleado_id = (int) $empleado_id;
+        if ( ! $empleado_id ) {
+            return;
+        }
+
+        // Asegura que los assets necesarios estén cargados.
+        cdb_grafica_enqueue_assets();
+
+        $criterios = cdb_get_criterios_empleado();
+        $labels    = array_map(
+            static function ( $grupo ) {
+                return strtok( $grupo, ' ' );
+            },
+            array_keys( $criterios )
+        );
+
+        $scores   = cdb_grafica_get_scores_by_role( $empleado_id, [ 'with_raw' => true ] );
+        $roles    = [ 'empleado', 'empleador', 'tutor' ];
+        $datasets = [];
+
+        foreach ( $roles as $rol ) {
+            $grupos = $scores['raw'][ $rol ]['grupos'] ?? [];
+            $data   = [];
+            $has    = false;
+            foreach ( $labels as $lab ) {
+                $valor = $grupos[ $lab ] ?? 0;
+                if ( $valor > 0 ) {
+                    $has = true;
+                }
+                $data[] = $valor;
+            }
+
+            if ( $has ) {
+                $datasets[] = [
+                    'label'           => cdb_empleado_plural_role( $rol ) . ' – ' . __( 'Puntuación de Gráfica', 'cdb-grafica' ) . ': ' . ( $scores['raw'][ $rol ]['total'] ?? 0 ),
+                    'data'            => $data,
+                    'backgroundColor' => cdb_grafica_get_color_by_role( $rol, 'background' ),
+                    'borderColor'     => cdb_grafica_get_color_by_role( $rol, 'border' ),
+                    'borderWidth'     => 2,
+                ];
+            }
+        }
+
+        $defaults_colors = [
+            'ticks_color'    => '#666666',
+            'ticks_backdrop' => '',
+        ];
+        $opts           = get_option( 'cdb_grafica_colores', [] );
+        $ticks_color    = $opts['ticks_color'] ?? $defaults_colors['ticks_color'];
+        $ticks_backdrop = $opts['ticks_backdrop'] ?? $defaults_colors['ticks_backdrop'];
+
+        $canvas_id = 'cdb-radar-EMP-' . $empleado_id;
+        ?>
+        <canvas id="<?php echo esc_attr( $canvas_id ); ?>"></canvas>
+        <script>
+        document.addEventListener('DOMContentLoaded', function(){
+            var canvas = document.getElementById('<?php echo esc_js( $canvas_id ); ?>');
+            if (!canvas || typeof Chart === 'undefined') { return; }
+            canvas.style.width = '100%';
+            canvas.style.height = '100%';
+            var ctx = canvas.getContext('2d');
+            var chartData = {
+                labels: <?php echo wp_json_encode( $labels ); ?>,
+                datasets: <?php echo wp_json_encode( $datasets ); ?>
+            };
+            var options = {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: { legend: { display: true } },
+                scales: {
+                    r: {
+                        ticks: {
+                            beginAtZero: true,
+                            stepSize: 1,
+                            max: 10,
+                            min: 0,
+                            color: <?php echo wp_json_encode( $ticks_color ); ?>,
+                            <?php if ( ! empty( $ticks_backdrop ) ) : ?>
+                            backdropColor: <?php echo wp_json_encode( $ticks_backdrop ); ?>,
+                            <?php endif; ?>
+                        },
+                        suggestedMin: 0,
+                        suggestedMax: 10
+                    }
+                }
+            };
+            new Chart(ctx, { type: 'radar', data: chartData, options: options });
+        });
+        </script>
+        <?php
+    }
+}
+
+// Punto único de render invocable desde cdb-empleado.
+add_action(
+    'cdb_grafica/render_radar_empleado',
+    function ( $empleado_id ) {
+        $empleado_id = (int) $empleado_id;
+        if ( ! $empleado_id ) {
+            return;
+        }
+        echo '<div class="cdb-radar-emp" data-cdb="radar-emp">';
+        cdb_grafica_output_radar_empleado( $empleado_id );
+        echo '</div>';
+    },
+    10,
+    1
+);
+
+// Exponer total para ranking si no existe.
+add_filter(
+    'cdb_grafica/get_total_empleado',
+    function ( $value, $empleado_id ) {
+        $total = get_post_meta( $empleado_id, '_cdb_total_grafica_empleado', true );
+        return is_numeric( $total ) ? (float) $total : $value;
+    },
+    10,
+    2
+);
+
+// ------------------------------------------------------------------
 // 2. Construye el HTML de la gráfica para un empleado específico.
 // ------------------------------------------------------------------
 function cdb_grafica_build_empleado_html( int $empleado_id, array $attrs = [] ): string {


### PR DESCRIPTION
## Summary
- expose `cdb_grafica_output_radar_empleado` for reusable employee radar rendering
- ensure radar canvas fills square container via Chart.js options
- expose filter for employee total

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a83f3ec4808327bcc6b155997885bc