### PR TITLE
feat: allow disabling auto-render of employee radar chart

### DIFF
--- a/inc/grafica-empleado.php
+++ b/inc/grafica-empleado.php
@@ -655,7 +655,7 @@ function cdb_grafica_build_empleado_form_html( int $empleado_id, array $args = [
     $embed_chart = apply_filters( 'cdb_grafica_empleado_form_embed_chart', ! empty( $args['embed_chart'] ), $post_id, $args );
 
     ob_start();
-    if ( $embed_chart ) {
+    if ( $embed_chart && apply_filters( 'cdb_grafica/auto_render_empleado_chart', true ) ) {
         echo apply_filters( 'cdb_grafica_empleado_html', '', $post_id, $args );
     }
     ?>


### PR DESCRIPTION
## Summary
- gate legacy employee radar rendering behind `cdb_grafica/auto_render_empleado_chart`
- keep radar rendering hook `cdb_grafica/render_radar_empleado` with `maintainAspectRatio: false`

## Testing
- `php -l inc/grafica-empleado.php`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8ad59afc08327a885389d6cddd32d