### PR TITLE
Centraliza el registro del menú de administrador

### DIFF
--- a/admin/menu.php
+++ b/admin/menu.php
@@ -1,0 +1,38 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Register the plugin's admin menu and submenus.
+ */
+function cdb_grafica_register_admin_menu() {
+    add_menu_page(
+        __( 'CdB Gráfica', 'cdb-grafica' ),
+        __( 'CdB Gráfica', 'cdb-grafica' ),
+        'manage_options',
+        'cdb_grafica_menu',
+        'cdb_grafica_dashboard_page',
+        'dashicons-chart-bar',
+        25
+    );
+
+    add_submenu_page(
+        'cdb_grafica_menu',
+        __( 'Modificar Criterios', 'cdb-grafica' ),
+        __( 'Modificar Criterios', 'cdb-grafica' ),
+        'manage_options',
+        'cdb_modificar_criterios',
+        'cdb_grafica_modificar_criterios_page'
+    );
+
+    add_submenu_page(
+        'cdb_grafica_menu',
+        __( 'Configurar Colores', 'cdb-grafica' ),
+        __( 'Configurar Colores', 'cdb-grafica' ),
+        'manage_options',
+        'cdb_modificar_colores',
+        'cdb_grafica_colores_page'
+    );
+}
+add_action( 'admin_menu', 'cdb_grafica_register_admin_menu' );

--- a/admin/modificar_colores.php
+++ b/admin/modificar_colores.php
@@ -2,19 +2,8 @@
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
-// Submenu page to modify graph colors
-function cdb_grafica_colores_menu() {
-    add_submenu_page(
-        'cdb_grafica_menu',
-        __( 'Configurar Colores', 'cdb-grafica' ),
-        __( 'Configurar Colores', 'cdb-grafica' ),
-        'manage_options',
-        'cdb_modificar_colores',
-        'cdb_grafica_colores_page'
-    );
-}
-add_action('admin_menu', 'cdb_grafica_colores_menu');
 
+// Renderiza la página de configuración de colores de la gráfica.
 function cdb_grafica_colores_page() {
     if (isset($_POST['cdb_grafica_colores_nonce']) && wp_verify_nonce($_POST['cdb_grafica_colores_nonce'], 'cdb_guardar_colores')) {
         $colores = [

--- a/admin/modificar_criterios.php
+++ b/admin/modificar_criterios.php
@@ -160,21 +160,7 @@ function cdb_grafica_build_snippet_notice( $grupo, $slug, $label, $desc, $visibl
     <?php
     return ob_get_clean();
 }
-// Agregar el menú principal del plugin en el panel de administración
-function cdb_grafica_menu() {
-    add_menu_page(
-        __( 'CdB Gráfica', 'cdb-grafica' ),
-        __( 'CdB Gráfica', 'cdb-grafica' ),
-        'manage_options',
-        'cdb_grafica_menu',
-        'cdb_grafica_dashboard_page',
-        'dashicons-chart-bar',
-        25
-    );
-}
-add_action('admin_menu', 'cdb_grafica_menu');
-
-// Función para renderizar la página principal de CdB Gráfica
+// Renderiza la página principal del menú de CdB Gráfica.
 function cdb_grafica_dashboard_page() {
     ?>
     <div class="wrap">
@@ -183,19 +169,6 @@ function cdb_grafica_dashboard_page() {
     </div>
     <?php
 }
-
-// Agregar la página de configuración en el menú de administración
-function cdb_grafica_modificar_criterios_menu() {
-    add_submenu_page(
-        'cdb_grafica_menu',
-        __( 'Modificar Criterios', 'cdb-grafica' ),
-        __( 'Modificar Criterios', 'cdb-grafica' ),
-        'manage_options',
-        'cdb_modificar_criterios',
-        'cdb_grafica_modificar_criterios_page'
-    );
-}
-add_action('admin_menu', 'cdb_grafica_modificar_criterios_menu');
 
 // Esta funcionalidad modifica archivos PHP en disco.
 // Solo los administradores deben utilizarla y las ediciones concurrentes

--- a/cdb-grafica.php
+++ b/cdb-grafica.php
@@ -26,7 +26,7 @@ register_activation_hook(__FILE__, 'grafica_bar_create_table');
 register_activation_hook(__FILE__, 'grafica_empleado_create_table');
 require_once plugin_dir_path(__FILE__) . 'admin/modificar_criterios.php';
 require_once plugin_dir_path(__FILE__) . 'admin/modificar_colores.php';
-
+require_once __DIR__ . '/admin/menu.php';
 
 // Requerir archivos de CPT y gráficas
 require_once __DIR__ . '/inc/criterios-bar.php';


### PR DESCRIPTION
## Resumen
- Añadido `admin/menu.php` para registrar el menú principal y sus submenús.
- Eliminados los hooks duplicados de menú en `modificar_criterios.php` y `modificar_colores.php`.
- Incluido `admin/menu.php` en el plugin principal.

## Pruebas
- `php -l admin/modificar_colores.php && php -l admin/modificar_criterios.php && php -l admin/menu.php && php -l cdb-grafica.php && echo "OK"`


------
https://chatgpt.com/codex/tasks/task_e_68acfe4a876c83278549c3c8298d2620