### PR TITLE
Allow customizing admin menu capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,15 @@ controla igualmente con `cdb_grafica_scores_ttl`.
 
 Tras guardar una valoración se ejecuta el hook `cdb_grafica_after_save`, que
 borra los transients anteriores.
+
+### `cdb_grafica_admin_capability`
+
+Permite modificar la capacidad requerida para acceder al menú de administración
+del plugin. Por defecto es `manage_options`, pero otros plugins o temas pueden
+ajustarla según sus necesidades:
+
+```php
+add_filter( 'cdb_grafica_admin_capability', function () {
+    return 'edit_posts';
+} );
+```

--- a/admin/menu.php
+++ b/admin/menu.php
@@ -7,10 +7,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Register the plugin's admin menu and submenus.
  */
 function cdb_grafica_register_admin_menu() {
+    $capability = apply_filters( 'cdb_grafica_admin_capability', 'manage_options' );
+
     add_menu_page(
         __( 'CdB Gráfica', 'cdb-grafica' ),
         __( 'CdB Gráfica', 'cdb-grafica' ),
-        'manage_options',
+        $capability,
         'cdb_grafica_menu',
         'cdb_grafica_dashboard_page',
         'dashicons-chart-bar',
@@ -21,7 +23,7 @@ function cdb_grafica_register_admin_menu() {
         'cdb_grafica_menu',
         __( 'Modificar Criterios', 'cdb-grafica' ),
         __( 'Modificar Criterios', 'cdb-grafica' ),
-        'manage_options',
+        $capability,
         'cdb_modificar_criterios',
         'cdb_grafica_modificar_criterios_page'
     );
@@ -30,7 +32,7 @@ function cdb_grafica_register_admin_menu() {
         'cdb_grafica_menu',
         __( 'Configurar Colores', 'cdb-grafica' ),
         __( 'Configurar Colores', 'cdb-grafica' ),
-        'manage_options',
+        $capability,
         'cdb_modificar_colores',
         'cdb_grafica_colores_page'
     );


### PR DESCRIPTION
## Summary
- allow changing admin menu capability via `cdb_grafica_admin_capability` filter
- document `cdb_grafica_admin_capability` in README

## Testing
- `php -l admin/menu.php`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad035125388327b0a7cde91f4ca974