### PR TITLE
Ignore compiled translation binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore compiled translation binaries
+*.mo

--- a/setup.sh
+++ b/setup.sh
@@ -11,3 +11,10 @@ if [ -f package.json ]; then
     npm ci
     npm run build
 fi
+
+# Compilar archivos de traducción (.po -> .mo)
+if compgen -G "languages/*.po" > /dev/null; then
+    for po in languages/*.po; do
+        msgfmt "$po" -o "${po%.po}.mo"
+    done
+fi


### PR DESCRIPTION
## Summary
- ignore compiled translation `.mo` files
- compile `.po` sources into `.mo` during setup

## Testing
- `npm test` *(fails: Missing script "test")*
- `bash setup.sh` *(fails: 403 Forbidden fetching @wordpress/scripts)*

------
https://chatgpt.com/codex/tasks/task_e_68ad08c70b748327b1b6a498019fa694