### PR TITLE
Move CdB Gráfica menu below CdB Form

### DIFF
--- a/admin/menu.php
+++ b/admin/menu.php
@@ -16,7 +16,7 @@ function cdb_grafica_register_admin_menu() {
         'cdb_grafica_menu',
         'cdb_grafica_dashboard_page',
         'dashicons-chart-bar',
-        25
+        26
     );
 
     add_submenu_page(


### PR DESCRIPTION
## Summary
- Align CdB Gráfica admin menu with CdB Form by lowering its position weight

## Testing
- `php -l admin/menu.php`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad102250748327bf1fb3b7e652f5bb