### PR TITLE
Add configurable graph styles

### DIFF
--- a/admin/menu.php
+++ b/admin/menu.php
@@ -36,5 +36,14 @@ function cdb_grafica_register_admin_menu() {
         'cdb_modificar_colores',
         'cdb_grafica_colores_page'
     );
+
+    add_submenu_page(
+        'cdb_grafica_menu',
+        __( 'Configurar Estilos', 'cdb-grafica' ),
+        __( 'Configurar Estilos', 'cdb-grafica' ),
+        $capability,
+        'cdb_estilos_grafica',
+        'cdb_grafica_estilos_page'
+    );
 }
 add_action( 'admin_menu', 'cdb_grafica_register_admin_menu' );

--- a/admin/modificar_estilos_grafica.php
+++ b/admin/modificar_estilos_grafica.php
@@ -1,0 +1,61 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+// Renderiza la página de configuración de estilos de la gráfica.
+function cdb_grafica_estilos_page() {
+    if ( isset( $_POST['cdb_grafica_estilos_nonce'] ) && wp_verify_nonce( $_POST['cdb_grafica_estilos_nonce'], 'cdb_guardar_estilos' ) ) {
+        $estilos = [
+            'border_width'     => isset($_POST['border_width']) ? intval($_POST['border_width']) : 2,
+            'legend_font_size' => isset($_POST['legend_font_size']) ? intval($_POST['legend_font_size']) : 14,
+            'ticks_step'       => isset($_POST['ticks_step']) ? intval($_POST['ticks_step']) : 1,
+            'ticks_min'        => isset($_POST['ticks_min']) ? intval($_POST['ticks_min']) : 0,
+            'ticks_max'        => isset($_POST['ticks_max']) ? intval($_POST['ticks_max']) : 10,
+        ];
+        update_option( 'cdb_grafica_estilos', $estilos );
+        echo '<div class="updated"><p>';
+        esc_html_e( 'Estilos actualizados.', 'cdb-grafica' );
+        echo '</p></div>';
+    }
+
+    $defaults = [
+        'border_width'     => 2,
+        'legend_font_size' => 14,
+        'ticks_step'       => 1,
+        'ticks_min'        => 0,
+        'ticks_max'        => 10,
+    ];
+    $estilos = get_option( 'cdb_grafica_estilos', $defaults );
+    ?>
+    <div class="wrap">
+        <h1><?php esc_html_e( 'Configurar Estilos', 'cdb-grafica' ); ?></h1>
+        <form method="post">
+            <?php wp_nonce_field( 'cdb_guardar_estilos', 'cdb_grafica_estilos_nonce' ); ?>
+            <table class="form-table">
+                <tr>
+                    <th scope="row"><?php esc_html_e( 'Ancho de borde', 'cdb-grafica' ); ?></th>
+                    <td><input type="number" name="border_width" value="<?php echo esc_attr( $estilos['border_width'] ); ?>" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><?php esc_html_e( 'Tamaño de fuente de la leyenda', 'cdb-grafica' ); ?></th>
+                    <td><input type="number" name="legend_font_size" value="<?php echo esc_attr( $estilos['legend_font_size'] ); ?>" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><?php esc_html_e( 'Step de ticks', 'cdb-grafica' ); ?></th>
+                    <td><input type="number" name="ticks_step" value="<?php echo esc_attr( $estilos['ticks_step'] ); ?>" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><?php esc_html_e( 'Mínimo de ticks', 'cdb-grafica' ); ?></th>
+                    <td><input type="number" name="ticks_min" value="<?php echo esc_attr( $estilos['ticks_min'] ); ?>" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><?php esc_html_e( 'Máximo de ticks', 'cdb-grafica' ); ?></th>
+                    <td><input type="number" name="ticks_max" value="<?php echo esc_attr( $estilos['ticks_max'] ); ?>" /></td>
+                </tr>
+            </table>
+            <?php submit_button(); ?>
+        </form>
+    </div>
+    <?php
+}

--- a/build/bar/index.js
+++ b/build/bar/index.js
@@ -1,1 +1,23 @@
-(()=>{"use strict";const e=window.wp.element,a=window.wp.blocks,o=window.wp.i18n;(0,a.registerBlockType)("cdb/grafica-bar",{title:"Gráfica Bar",icon:"chart-area",category:"widgets",edit:()=>(0,e.createElement)("div",null,(0,e.createElement)("p",null,'El bloque "Gráfica Bar" está funcionando correctamente. La configuración de colores ha sido eliminada para mayor estabilidad.')),save:()=>null}),document.addEventListener("DOMContentLoaded",(function(){console.log("El DOM está cargado.");const e=document.getElementById("grafica-bar");if(!e)return void console.error("No se encontró el elemento con id 'grafica-bar'.");const a=document.createElement("canvas");e.appendChild(a);const t=a.getContext("2d");if(e&&t){const a=JSON.parse(e.dataset.valores),r={labels:a.labels,datasets:[{label:`${(0,o.__)("Puntuación de Gráfica","cdb-grafica")}: ${a.total.toFixed(1)}`,data:a.promedios,backgroundColor:e.dataset.backgroundColor||"rgba(75, 192, 192, 0.2)",borderColor:e.dataset.borderColor||"rgba(75, 192, 192, 1)",borderWidth:2}]};new Chart(t,{type:"radar",data:r,options:{responsive:!0,plugins:{legend:{display:!0,labels:{font:{size:14}}}},scales:{r:{ticks:{beginAtZero:!0,stepSize:1,max:10,min:0,color:e.dataset.ticksColor||"#666",backdropColor:e.dataset.ticksBackdropColor||void 0}}}}}),console.log("Gráfica creada correctamente.")}}))})();
+(()=>{"use strict";
+const e=window.wp.element,a=window.wp.blocks,o=window.wp.i18n;
+(0,a.registerBlockType)("cdb/grafica-bar",{title:"Gráfica Bar",icon:"chart-area",category:"widgets",edit:()=> (0,e.createElement)("div",null,(0,e.createElement)("p",null,'El bloque "Gráfica Bar" está funcionando correctamente. La configuración de colores ha sido eliminada para mayor estabilidad.')),save:()=>null});
+document.addEventListener("DOMContentLoaded",function(){
+    console.log("El DOM está cargado.");
+    const e=document.getElementById("grafica-bar");
+    if(!e){console.error("No se encontró el elemento con id 'grafica-bar'.");return;}
+    const a=document.createElement("canvas");
+    e.appendChild(a);
+    const t=a.getContext("2d");
+    if(e&&t){
+        const a=JSON.parse(e.dataset.valores),
+            r=parseInt(e.dataset.borderWidth,10)||2,
+            n=parseInt(e.dataset.legendFont,10)||14,
+            i=parseInt(e.dataset.ticksStep,10)||1,
+            l=parseInt(e.dataset.ticksMin,10)||0,
+            c=parseInt(e.dataset.ticksMax,10)||10,
+            s={labels:a.labels,datasets:[{label:`${(0,o.__)("Puntuación de Gráfica","cdb-grafica")}: ${a.total.toFixed(1)}`,data:a.promedios,backgroundColor:e.dataset.backgroundColor||"rgba(75, 192, 192, 0.2)",borderColor:e.dataset.borderColor||"rgba(75, 192, 192, 1)",borderWidth:r}]};
+        new Chart(t,{type:"radar",data:s,options:{responsive:!0,plugins:{legend:{display:!0,labels:{font:{size:n}}}},scales:{r:{ticks:{beginAtZero:!0,stepSize:i,max:c,min:l,color:e.dataset.ticksColor||"#666",backdropColor:e.dataset.ticksBackdropColor||void 0}}}}});
+        console.log("Gráfica creada correctamente.");
+    }
+});
+})();

--- a/build/empleado/index.js
+++ b/build/empleado/index.js
@@ -1,1 +1,28 @@
-(()=>{"use strict";const e=window.wp.blocks,o=window.ReactJSXRuntime;(0,e.registerBlockType)("cdb/grafica-empleado",{title:"Gráfica Empleado",icon:"chart-area",category:"widgets",edit:()=>(0,o.jsx)("div",{children:(0,o.jsx)("p",{children:'El bloque "Gráfica Empleado" está funcionando correctamente.'})}),save:()=>null}),document.addEventListener("DOMContentLoaded",(function(){console.log("El DOM está cargado.");const e=document.getElementById("grafica-empleado");if(!e)return void console.error("No se encontró el elemento con id 'grafica-empleado'.");const o=document.createElement("canvas");e.appendChild(o);const a=o.getContext("2d");if(e&&a){const o=JSON.parse(e.dataset.valores),t=JSON.parse(e.dataset.roleColors||"{}"),r={labels:o.labels,datasets:[]};Array.isArray(o.datasets)&&o.datasets.forEach((e=>{const o=t[e.role]||{};r.datasets.push({label:e.label,data:e.data,backgroundColor:o.background||"gray",borderColor:o.border||"gray",borderWidth:2})}));new Chart(a,{type:"radar",data:r,options:{responsive:!0,plugins:{legend:{display:!0,labels:{font:{size:14}}}},scales:{r:{ticks:{beginAtZero:!0,stepSize:1,max:10,min:0,color:e.dataset.ticksColor||"#666",backdropColor:e.dataset.ticksBackdropColor||void 0}}}}}),console.log("Gráfica creada correctamente.")}}))})();
+(()=>{"use strict";
+const a=window.wp.blocks,o=window.ReactJSXRuntime;
+(0,a.registerBlockType)("cdb/grafica-empleado",{title:"Gráfica Empleado",icon:"chart-area",category:"widgets",edit:()=> (0,o.jsx)("div",{children:(0,o.jsx)("p",{children:'El bloque "Gráfica Empleado" está funcionando correctamente.'})}),save:()=>null});
+document.addEventListener("DOMContentLoaded",function(){
+    console.log("El DOM está cargado.");
+    const e=document.getElementById("grafica-empleado");
+    if(!e){console.error("No se encontró el elemento con id 'grafica-empleado'.");return;}
+    const a=document.createElement("canvas");
+    e.appendChild(a);
+    const t=a.getContext("2d");
+    if(e&&t){
+        const a=JSON.parse(e.dataset.valores),
+            r=JSON.parse(e.dataset.roleColors||"{}"),
+            n=parseInt(e.dataset.borderWidth,10)||2,
+            l=parseInt(e.dataset.legendFont,10)||14,
+            i=parseInt(e.dataset.ticksStep,10)||1,
+            c=parseInt(e.dataset.ticksMin,10)||0,
+            d=parseInt(e.dataset.ticksMax,10)||10,
+            s={labels:a.labels,datasets:[]};
+        Array.isArray(a.datasets)&&a.datasets.forEach(dset=>{
+            const cfg=r[dset.role]||{};
+            s.datasets.push({label:dset.label,data:dset.data,backgroundColor:cfg.background||"gray",borderColor:cfg.border||"gray",borderWidth:n});
+        });
+        new Chart(t,{type:"radar",data:s,options:{responsive:!0,plugins:{legend:{display:!0,labels:{font:{size:l}}}},scales:{r:{ticks:{beginAtZero:!0,stepSize:i,max:d,min:c,color:e.dataset.ticksColor||"#666",backdropColor:e.dataset.ticksBackdropColor||void 0}}}}});
+        console.log("Gráfica creada correctamente.");
+    }
+});
+})();

--- a/cdb-grafica.php
+++ b/cdb-grafica.php
@@ -26,6 +26,7 @@ register_activation_hook(__FILE__, 'grafica_bar_create_table');
 register_activation_hook(__FILE__, 'grafica_empleado_create_table');
 require_once plugin_dir_path(__FILE__) . 'admin/modificar_criterios.php';
 require_once plugin_dir_path(__FILE__) . 'admin/modificar_colores.php';
+require_once plugin_dir_path(__FILE__) . 'admin/modificar_estilos_grafica.php';
 require_once __DIR__ . '/admin/menu.php';
 
 // Requerir archivos de CPT y gráficas

--- a/inc/grafica-bar.php
+++ b/inc/grafica-bar.php
@@ -121,14 +121,28 @@ $results = $wpdb->get_results($wpdb->prepare("
     $attributes['ticksColor']        = $opts['ticks_color'] ?? $defaults['ticks_color'];
     $attributes['ticksBackdropColor'] = $opts['ticks_backdrop'] ?? $defaults['ticks_backdrop'];
 
+    $style_defaults = [
+        'border_width'     => 2,
+        'legend_font_size' => 14,
+        'ticks_step'       => 1,
+        'ticks_min'        => 0,
+        'ticks_max'        => 10,
+    ];
+    $estilos = get_option( 'cdb_grafica_estilos', $style_defaults );
+
     ob_start();
     ?>
     <div id="grafica-bar"
          data-valores="<?php echo esc_attr(wp_json_encode($data)); ?>"
          data-background-color="<?php echo esc_attr($attributes['backgroundColor']); ?>"
          data-border-color="<?php echo esc_attr($attributes['borderColor']); ?>"
+         data-border-width="<?php echo esc_attr( $estilos['border_width'] ); ?>"
+         data-legend-font="<?php echo esc_attr( $estilos['legend_font_size'] ); ?>"
          data-ticks-color="<?php echo esc_attr($attributes['ticksColor']); ?>"
-         data-ticks-backdrop-color="<?php echo esc_attr($attributes['ticksBackdropColor']); ?>">
+         data-ticks-backdrop-color="<?php echo esc_attr($attributes['ticksBackdropColor']); ?>"
+         data-ticks-step="<?php echo esc_attr( $estilos['ticks_step'] ); ?>"
+         data-ticks-min="<?php echo esc_attr( $estilos['ticks_min'] ); ?>"
+         data-ticks-max="<?php echo esc_attr( $estilos['ticks_max'] ); ?>">
     </div>
     <?php
     return ob_get_clean();

--- a/inc/grafica-empleado.php
+++ b/inc/grafica-empleado.php
@@ -251,6 +251,15 @@ function cdb_grafica_build_empleado_html( int $empleado_id, array $attrs = [] ):
     $attrs['ticksColor']         = $opts['ticks_color'] ?? $defaults_colors['ticks_color'];
     $attrs['ticksBackdropColor'] = $opts['ticks_backdrop'] ?? $defaults_colors['ticks_backdrop'];
 
+    $style_defaults = [
+        'border_width'     => 2,
+        'legend_font_size' => 14,
+        'ticks_step'       => 1,
+        'ticks_min'        => 0,
+        'ticks_max'        => 10,
+    ];
+    $estilos = get_option( 'cdb_grafica_estilos', $style_defaults );
+
     $div_id = 'grafica-empleado';
     if ( ! empty( $attrs['id_suffix'] ) ) {
         $div_id .= '-' . sanitize_key( $attrs['id_suffix'] );
@@ -262,11 +271,16 @@ function cdb_grafica_build_empleado_html( int $empleado_id, array $attrs = [] ):
     ?>
     <div id="<?php echo esc_attr( $div_id ); ?>"<?php echo $class_attr . $style_attr; ?>
          data-valores="<?php echo esc_attr( wp_json_encode( $data ) ); ?>"
-         data-role-colors="<?php echo esc_attr( wp_json_encode( $role_colors ) ); ?>"
-         data-background-color="<?php echo esc_attr( $attrs['backgroundColor'] ); ?>"
-         data-border-color="<?php echo esc_attr( $attrs['borderColor'] ); ?>"
-         data-ticks-color="<?php echo esc_attr( $attrs['ticksColor'] ); ?>"
-         data-ticks-backdrop-color="<?php echo esc_attr( $attrs['ticksBackdropColor'] ); ?>">
+        data-role-colors="<?php echo esc_attr( wp_json_encode( $role_colors ) ); ?>"
+        data-background-color="<?php echo esc_attr( $attrs['backgroundColor'] ); ?>"
+        data-border-color="<?php echo esc_attr( $attrs['borderColor'] ); ?>"
+        data-border-width="<?php echo esc_attr( $estilos['border_width'] ); ?>"
+        data-legend-font="<?php echo esc_attr( $estilos['legend_font_size'] ); ?>"
+        data-ticks-color="<?php echo esc_attr( $attrs['ticksColor'] ); ?>"
+        data-ticks-backdrop-color="<?php echo esc_attr( $attrs['ticksBackdropColor'] ); ?>"
+        data-ticks-step="<?php echo esc_attr( $estilos['ticks_step'] ); ?>"
+        data-ticks-min="<?php echo esc_attr( $estilos['ticks_min'] ); ?>"
+        data-ticks-max="<?php echo esc_attr( $estilos['ticks_max'] ); ?>">
     </div>
     <?php
     return ob_get_clean();

--- a/src/bar/index.js
+++ b/src/bar/index.js
@@ -32,6 +32,11 @@ document.addEventListener("DOMContentLoaded", function () {
 
     if (graficaBarElement && ctx) {
         const data = JSON.parse(graficaBarElement.dataset.valores);
+        const borderWidth = parseInt(graficaBarElement.dataset.borderWidth, 10) || 2;
+        const legendFont = parseInt(graficaBarElement.dataset.legendFont, 10) || 14;
+        const ticksStep = parseInt(graficaBarElement.dataset.ticksStep, 10) || 1;
+        const ticksMin = parseInt(graficaBarElement.dataset.ticksMin, 10) || 0;
+        const ticksMax = parseInt(graficaBarElement.dataset.ticksMax, 10) || 10;
 
         const chartData = {
             labels: data.labels,
@@ -41,7 +46,7 @@ document.addEventListener("DOMContentLoaded", function () {
                     data: data.promedios,
                     backgroundColor: graficaBarElement.dataset.backgroundColor || "rgba(75, 192, 192, 0.2)",
                     borderColor: graficaBarElement.dataset.borderColor || "rgba(75, 192, 192, 1)",
-                    borderWidth: 2,
+                    borderWidth: borderWidth,
                 },
             ],
         };
@@ -54,16 +59,16 @@ document.addEventListener("DOMContentLoaded", function () {
                 plugins: {
                     legend: {
                         display: true,
-                        labels: { font: { size: 14 } },
+                        labels: { font: { size: legendFont } },
                     },
                 },
                 scales: {
                     r: {
                         ticks: {
                             beginAtZero: true,
-                            stepSize: 1,
-                            max: 10,
-                            min: 0,
+                            stepSize: ticksStep,
+                            max: ticksMax,
+                            min: ticksMin,
                             color: graficaBarElement.dataset.ticksColor || '#666',
                             backdropColor: graficaBarElement.dataset.ticksBackdropColor || undefined,
                         },

--- a/src/empleado/index.js
+++ b/src/empleado/index.js
@@ -32,6 +32,11 @@ document.addEventListener("DOMContentLoaded", function () {
     if (graficaEmpleadoElement && ctx) {
         const data = JSON.parse(graficaEmpleadoElement.dataset.valores);
         const colores = JSON.parse(graficaEmpleadoElement.dataset.roleColors || "{}");
+        const borderWidth = parseInt(graficaEmpleadoElement.dataset.borderWidth, 10) || 2;
+        const legendFont = parseInt(graficaEmpleadoElement.dataset.legendFont, 10) || 14;
+        const ticksStep = parseInt(graficaEmpleadoElement.dataset.ticksStep, 10) || 1;
+        const ticksMin = parseInt(graficaEmpleadoElement.dataset.ticksMin, 10) || 0;
+        const ticksMax = parseInt(graficaEmpleadoElement.dataset.ticksMax, 10) || 10;
 
         const chartData = {
             labels: data.labels,
@@ -46,7 +51,7 @@ document.addEventListener("DOMContentLoaded", function () {
                     data: dataset.data,
                     backgroundColor: cfg.background || "gray",
                     borderColor: cfg.border || "gray",
-                    borderWidth: 2,
+                    borderWidth: borderWidth,
                 });
             });
         }
@@ -59,16 +64,16 @@ document.addEventListener("DOMContentLoaded", function () {
                 plugins: {
                     legend: {
                         display: true,
-                        labels: { font: { size: 14 } },
+                        labels: { font: { size: legendFont } },
                     },
                 },
                 scales: {
                     r: {
                         ticks: {
                             beginAtZero: true,
-                            stepSize: 1,
-                            max: 10,
-                            min: 0,
+                            stepSize: ticksStep,
+                            max: ticksMax,
+                            min: ticksMin,
                             color: graficaEmpleadoElement.dataset.ticksColor || '#666',
                             backdropColor: graficaEmpleadoElement.dataset.ticksBackdropColor || undefined,
                         },


### PR DESCRIPTION
## Summary
- add admin page to configure border width, legend font size, and tick steps for graphs
- pass configured styles to graph blocks and scripts
- expose style values in chart rendering

## Testing
- `npm install` *(fails: 403 Forbidden @wordpress/scripts)*
- `npm run build` *(fails: wp-scripts not found)*
- `php -l admin/menu.php`
- `php -l admin/modificar_estilos_grafica.php`
- `php -l cdb-grafica.php`
- `php -l inc/grafica-bar.php`
- `php -l inc/grafica-empleado.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad183416388327851e4a34015d5418