### PR TITLE
feat: add customizable interface styles

### DIFF
--- a/admin/menu.php
+++ b/admin/menu.php
@@ -45,5 +45,14 @@ function cdb_grafica_register_admin_menu() {
         'cdb_estilos_grafica',
         'cdb_grafica_estilos_page'
     );
+
+    add_submenu_page(
+        'cdb_grafica_menu',
+        __( 'Estilos de Interfaz', 'cdb-grafica' ),
+        __( 'Estilos de Interfaz', 'cdb-grafica' ),
+        $capability,
+        'cdb_estilos_interfaz',
+        'cdb_grafica_ui_page'
+    );
 }
 add_action( 'admin_menu', 'cdb_grafica_register_admin_menu' );

--- a/admin/modificar_estilos_interfaz.php
+++ b/admin/modificar_estilos_interfaz.php
@@ -1,0 +1,86 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+// Renderiza la página de configuración de estilos de la interfaz.
+function cdb_grafica_ui_page() {
+    if ( isset( $_POST['cdb_grafica_ui_nonce'] ) && wp_verify_nonce( $_POST['cdb_grafica_ui_nonce'], 'cdb_guardar_ui_estilos' ) ) {
+        $estilos = [
+            'accordion_bg'       => sanitize_hex_color( $_POST['accordion_bg'] ?? '' ),
+            'accordion_border'   => sanitize_hex_color( $_POST['accordion_border'] ?? '' ),
+            'accordion_hover'    => sanitize_hex_color( $_POST['accordion_hover'] ?? '' ),
+            'form_bg'            => sanitize_hex_color( $_POST['form_bg'] ?? '' ),
+            'form_border'        => sanitize_hex_color( $_POST['form_border'] ?? '' ),
+            'table_header_bg'    => sanitize_hex_color( $_POST['table_header_bg'] ?? '' ),
+            'table_header_color' => sanitize_hex_color( $_POST['table_header_color'] ?? '' ),
+            'font_family'        => sanitize_text_field( $_POST['font_family'] ?? '' ),
+        ];
+        update_option( 'cdb_grafica_ui_estilos', $estilos );
+        echo '<div class="updated"><p>';
+        esc_html_e( 'Estilos de interfaz actualizados.', 'cdb-grafica' );
+        echo '</p></div>';
+    }
+
+    $defaults = [
+        'accordion_bg'       => '#FAF8EE',
+        'accordion_border'   => '#cdb888',
+        'accordion_hover'    => '#cdb121',
+        'form_bg'            => '#FAF8EE',
+        'form_border'        => '#cdb888',
+        'table_header_bg'    => '#cdb121',
+        'table_header_color' => '#000000',
+        'font_family'        => 'Arial, sans-serif',
+    ];
+    $estilos = wp_parse_args( get_option( 'cdb_grafica_ui_estilos', [] ), $defaults );
+
+    wp_enqueue_style( 'wp-color-picker' );
+    wp_enqueue_script( 'wp-color-picker' );
+    ?>
+    <div class="wrap">
+        <h1><?php esc_html_e( 'Configurar Estilos de Interfaz', 'cdb-grafica' ); ?></h1>
+        <form method="post">
+            <?php wp_nonce_field( 'cdb_guardar_ui_estilos', 'cdb_grafica_ui_nonce' ); ?>
+            <table class="form-table">
+                <tr>
+                    <th scope="row"><?php esc_html_e( 'Acordeón - Fondo', 'cdb-grafica' ); ?></th>
+                    <td><input type="text" name="accordion_bg" value="<?php echo esc_attr( $estilos['accordion_bg'] ); ?>" class="cdb-color-field" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><?php esc_html_e( 'Acordeón - Borde', 'cdb-grafica' ); ?></th>
+                    <td><input type="text" name="accordion_border" value="<?php echo esc_attr( $estilos['accordion_border'] ); ?>" class="cdb-color-field" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><?php esc_html_e( 'Acordeón - Hover', 'cdb-grafica' ); ?></th>
+                    <td><input type="text" name="accordion_hover" value="<?php echo esc_attr( $estilos['accordion_hover'] ); ?>" class="cdb-color-field" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><?php esc_html_e( 'Formulario - Fondo', 'cdb-grafica' ); ?></th>
+                    <td><input type="text" name="form_bg" value="<?php echo esc_attr( $estilos['form_bg'] ); ?>" class="cdb-color-field" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><?php esc_html_e( 'Formulario - Borde', 'cdb-grafica' ); ?></th>
+                    <td><input type="text" name="form_border" value="<?php echo esc_attr( $estilos['form_border'] ); ?>" class="cdb-color-field" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><?php esc_html_e( 'Cabecera de Tabla - Fondo', 'cdb-grafica' ); ?></th>
+                    <td><input type="text" name="table_header_bg" value="<?php echo esc_attr( $estilos['table_header_bg'] ); ?>" class="cdb-color-field" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><?php esc_html_e( 'Cabecera de Tabla - Color', 'cdb-grafica' ); ?></th>
+                    <td><input type="text" name="table_header_color" value="<?php echo esc_attr( $estilos['table_header_color'] ); ?>" class="cdb-color-field" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><?php esc_html_e( 'Tipografía global', 'cdb-grafica' ); ?></th>
+                    <td><input type="text" name="font_family" value="<?php echo esc_attr( $estilos['font_family'] ); ?>" /></td>
+                </tr>
+            </table>
+            <?php submit_button(); ?>
+        </form>
+    </div>
+    <script>
+    jQuery(function($){ $('.cdb-color-field').wpColorPicker(); });
+    </script>
+    <?php
+}
+

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,6 +1,6 @@
 /* Estilos básicos del plugin CdB_grafica */
 body {
-    font-family: Arial, sans-serif;
+    font-family: var(--cdb-font-family, Arial, sans-serif);
 }
 
 .cdb-scores-legend {

--- a/cdb-grafica.php
+++ b/cdb-grafica.php
@@ -27,6 +27,7 @@ register_activation_hook(__FILE__, 'grafica_empleado_create_table');
 require_once plugin_dir_path(__FILE__) . 'admin/modificar_criterios.php';
 require_once plugin_dir_path(__FILE__) . 'admin/modificar_colores.php';
 require_once plugin_dir_path(__FILE__) . 'admin/modificar_estilos_grafica.php';
+require_once plugin_dir_path(__FILE__) . 'admin/modificar_estilos_interfaz.php';
 require_once __DIR__ . '/admin/menu.php';
 
 // Requerir archivos de CPT y gráficas

--- a/inc/grafica-empleado.php
+++ b/inc/grafica-empleado.php
@@ -68,6 +68,29 @@ function cdb_grafica_enqueue_assets(): void {
         );
     }
 
+    $ui_defaults = [
+        'accordion_bg'       => '#FAF8EE',
+        'accordion_border'   => '#cdb888',
+        'accordion_hover'    => '#cdb121',
+        'form_bg'            => '#FAF8EE',
+        'form_border'        => '#cdb888',
+        'table_header_bg'    => '#cdb121',
+        'table_header_color' => '#000000',
+        'font_family'        => 'Arial, sans-serif',
+    ];
+    $ui_estilos = wp_parse_args( get_option( 'cdb_grafica_ui_estilos', [] ), $ui_defaults );
+    $css  = ':root{';
+    $css .= '--cdb-accordion-bg:' . sanitize_hex_color( $ui_estilos['accordion_bg'] ) . ';';
+    $css .= '--cdb-accordion-border:' . sanitize_hex_color( $ui_estilos['accordion_border'] ) . ';';
+    $css .= '--cdb-accordion-hover:' . sanitize_hex_color( $ui_estilos['accordion_hover'] ) . ';';
+    $css .= '--cdb-form-bg:' . sanitize_hex_color( $ui_estilos['form_bg'] ) . ';';
+    $css .= '--cdb-form-border:' . sanitize_hex_color( $ui_estilos['form_border'] ) . ';';
+    $css .= '--cdb-table-header-bg:' . sanitize_hex_color( $ui_estilos['table_header_bg'] ) . ';';
+    $css .= '--cdb-table-header-color:' . sanitize_hex_color( $ui_estilos['table_header_color'] ) . ';';
+    $css .= '--cdb-font-family:' . sanitize_text_field( $ui_estilos['font_family'] ) . ';';
+    $css .= '}';
+    wp_add_inline_style( 'cdb-grafica-style', $css );
+
     if ( ! wp_script_is( 'cdb-grafica-script', 'enqueued' ) ) {
         wp_enqueue_script(
             'cdb-grafica-script',

--- a/style.css
+++ b/style.css
@@ -1,16 +1,30 @@
 /* Estilos para la tabla con acordeón */
+:root {
+    --cdb-accordion-bg: #FAF8EE;
+    --cdb-accordion-border: #cdb888;
+    --cdb-accordion-hover: #cdb121;
+    --cdb-form-bg: #FAF8EE;
+    --cdb-form-border: #cdb888;
+    --cdb-table-header-bg: #cdb121;
+    --cdb-table-header-color: #000000;
+    --cdb-font-family: Arial, sans-serif;
+}
+
+body {
+    font-family: var(--cdb-font-family, Arial, sans-serif);
+}
 .accordion {
     margin: 1em 0; /* Margen superior e inferior */
-    border: 1px solid #cdb888;
+    border: 1px solid var(--cdb-accordion-border);
     border-radius: 5px;
     overflow: hidden;
 }
 
 .accordion-header {
-    background-color: #FAF8EE; /* Fondo blanco */
+    background-color: var(--cdb-accordion-bg); /* Fondo blanco */
     padding: 10px 15px;
     cursor: pointer;
-    border-bottom: 1px solid #cdb888;
+    border-bottom: 1px solid var(--cdb-accordion-border);
     color: #000; /* Texto negro */
     font-weight: bold;
     border-radius: 5px; /* Bordes redondeados */
@@ -18,7 +32,7 @@
 }
 
 .accordion-header:hover {
-    background-color: #cdb121; /* Fondo más oscuro al pasar el ratón */
+    background-color: var(--cdb-accordion-hover); /* Fondo más oscuro al pasar el ratón */
 }
 
 .accordion-header .accordion-toggle {
@@ -31,7 +45,7 @@
 .accordion-content {
     display: none;
     padding: 15px;
-    background-color: #FAF8EE; /* Fondo blanco */
+    background-color: var(--cdb-accordion-bg); /* Fondo blanco */
 }
 
 .accordion-item.open > .accordion-content { display: block; }
@@ -48,7 +62,7 @@
     max-width: 300px;
     padding: 5px;
     margin-top: 5px;
-    border: 1px solid #cdb888;
+    border: 1px solid var(--cdb-accordion-border);
     border-radius: 3px;
 }
 
@@ -57,8 +71,8 @@ form {
     margin: 3em auto 2em auto; /* 3em arriba, 2em abajo */
     max-width: 800px; /* Ancho máximo para centrar el formulario */
     padding: 1em; /* Espaciado interno */
-    background-color: #FAF8EE; /* Fondo blanco */
-    border: 1px solid #cdb888; /* Borde ligero */
+    background-color: var(--cdb-form-bg); /* Fondo blanco */
+    border: 1px solid var(--cdb-form-border); /* Borde ligero */
     border-radius: 5px; /* Bordes redondeados */
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); /* Sombra suave */
 }
@@ -120,8 +134,8 @@ form {
 .cdb-grafica-scores th.criterio-cell small { margin:2px 0 0; }
 
 .cdb-grafica-scores .group-header th {
-    background:#cdb121;
-    color:#000;
+    background: var(--cdb-table-header-bg);
+    color: var(--cdb-table-header-color);
     font-weight:700;
     padding:.25em .5em;
     padding-left:0;


### PR DESCRIPTION
## Summary
- add "Estilos de Interfaz" submenu
- create UI style settings page with color pickers and font family option
- replace hardcoded colors with CSS variables and inject saved values inline

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad1c2f9ea08327be410be64d04c0df