### PR TITLE
Add header row and responsive styles for scores table

### DIFF
--- a/inc/grafica-empleado.php
+++ b/inc/grafica-empleado.php
@@ -725,6 +725,14 @@ function cdb_grafica_build_empleado_scores_table_html( int $empleado_id, array $
             <col class="col-empdr" style="width:3ch">
             <col class="col-tutor" style="width:3ch">
         </colgroup>
+        <thead>
+            <tr>
+                <th scope="col"></th>
+                <th scope="col"><?php esc_html_e( 'Empleados', 'cdb-grafica' ); ?></th>
+                <th scope="col"><?php esc_html_e( 'Empleadores', 'cdb-grafica' ); ?></th>
+                <th scope="col"><?php esc_html_e( 'Tutores', 'cdb-grafica' ); ?></th>
+            </tr>
+        </thead>
         <?php foreach ( $criterios as $grupo_nombre => $campos ) : ?>
         <tbody class="grupo">
             <tr class="group-header">

--- a/style.css
+++ b/style.css
@@ -141,6 +141,14 @@ form {
     padding-left:0;
     text-align:left;
 }
+.cdb-grafica-scores thead th {
+    background: var(--cdb-table-header-bg);
+    color: var(--cdb-table-header-color);
+    font-family: var(--cdb-font-family);
+    font-weight:700;
+    padding:.25em .5em;
+    text-align:center;
+}
 .cdb-grafica-scores .group-toggle {
     all:unset;
     display:block;
@@ -170,3 +178,11 @@ form {
 .cdb-grafica-scores .col-empdr,
 .cdb-grafica-scores .col-tutor { width:3ch; }
 .cdb-grafica-scores .col-criterio { width:auto; }
+
+@media (max-width: 600px) {
+    .cdb-grafica-scores thead th {
+        font-size:0.875rem;
+        padding:.2em .3em;
+        text-align:center;
+    }
+}


### PR DESCRIPTION
## Summary
- Add table header to employee scores table with employee, employer, and tutor columns
- Style header cells and add responsive tweaks for mobile

## Testing
- `php -l inc/grafica-empleado.php`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b3241276f48327a625fbb3b290ae7f