### PR TITLE
Remove native button styling for score group toggle

### DIFF
--- a/style.css
+++ b/style.css
@@ -143,6 +143,11 @@ form {
 }
 .cdb-grafica-scores .group-toggle {
     all:unset;
+    appearance:none;
+    -webkit-appearance:none;
+    -moz-appearance:none;
+    background:none;
+    border:0;
     display:block;
     width:100%;
     text-align:left;


### PR DESCRIPTION
## Summary
- remove native browser styling from `.cdb-grafica-scores .group-toggle`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b329c470508327b9cdf25ba919b7d6