### PR TITLE
Refine score group toggle styling and spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -143,12 +143,17 @@ form {
 }
 .cdb-grafica-scores .group-toggle {
     all:unset;
+    appearance:none;
+    -webkit-appearance:none;
+    -moz-appearance:none;
+    background:none;
+    border:0;
     display:block;
     width:100%;
     text-align:left;
     cursor:pointer;
     position:relative;
-    padding-left:1.5em;
+    padding-left:2em;
 }
 
 .cdb-grafica-scores .group-toggle::before {


### PR DESCRIPTION
## Summary
- remove native browser styling from `.cdb-grafica-scores .group-toggle`
- increase space between the arrow icon and score group title

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b329c470508327b9cdf25ba919b7d6