### PR TITLE
Añadir promedios de grupo en tabla de calificaciones

### DIFF
--- a/inc/grafica-empleado.php
+++ b/inc/grafica-empleado.php
@@ -691,6 +691,22 @@ function cdb_grafica_build_empleado_scores_table_html( int $empleado_id, array $
         }
     }
 
+    $group_scores = [];
+    foreach ( $criterios as $grupo_nombre => $campos ) {
+        foreach ( $roles as $rol ) {
+            $suma   = 0;
+            $cuenta = 0;
+            foreach ( $campos as $campo_slug => $info ) {
+                $valor = $scores[ $rol ][ $campo_slug ] ?? null;
+                if ( null !== $valor ) {
+                    $suma += $valor;
+                    $cuenta++;
+                }
+            }
+            $group_scores[ $grupo_nombre ][ $rol ] = $cuenta > 0 ? ( $suma / $cuenta ) : null;
+        }
+    }
+
     $c_emp   = cdb_grafica_get_color_by_role( 'empleado' );
     $c_empdr = cdb_grafica_get_color_by_role( 'empleador' );
     $c_tutor = cdb_grafica_get_color_by_role( 'tutor' );
@@ -728,11 +744,14 @@ function cdb_grafica_build_empleado_scores_table_html( int $empleado_id, array $
         <?php foreach ( $criterios as $grupo_nombre => $campos ) : ?>
         <tbody class="grupo">
             <tr class="group-header">
-                <th colspan="4">
+                <th class="criterio-cell">
                     <button class="group-toggle" type="button" aria-expanded="false">
                         <?php echo esc_html( $grupo_nombre ); ?>
                     </button>
                 </th>
+                <?php foreach ( $roles as $rol ) : ?>
+                    <td class="score-cell"><?php $print_cell( $group_scores[ $grupo_nombre ][ $rol ] ?? null ); ?></td>
+                <?php endforeach; ?>
             </tr>
             <?php foreach ( $campos as $campo_slug => $info ) : ?>
                 <tr>

--- a/style.css
+++ b/style.css
@@ -133,13 +133,19 @@ form {
 
 .cdb-grafica-scores th.criterio-cell small { margin:2px 0 0; }
 
-.cdb-grafica-scores .group-header th {
+.cdb-grafica-scores .group-header th,
+.cdb-grafica-scores .group-header td {
     background: var(--cdb-table-header-bg);
     color: var(--cdb-table-header-color);
     font-weight:700;
     padding:.25em .5em;
+}
+.cdb-grafica-scores .group-header th {
     padding-left:0;
     text-align:left;
+}
+.cdb-grafica-scores .group-header .score-cell {
+    text-align:center;
 }
 .cdb-grafica-scores .group-toggle {
     all:unset;


### PR DESCRIPTION
## Summary
- Calcula promedios de cada grupo para todos los roles y los muestra en la cabecera del grupo.
- Ajusta estilos de la cabecera y celdas de promedios.

## Testing
- `php -l inc/grafica-empleado.php`
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b38c4b92608327ba29edef09aeabe0